### PR TITLE
Append metadata operation

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -63,10 +63,15 @@ The namedgraph used for the incoming metadata quads.
 The operation updates subjects with a type that's a 'well known dataset class', currently:
 
 * http://rdfs.org/ns/void#Dataset
-* http://schema.org/Dataset,
-* http://www.w3.org/ns/dcat#Dataset,
+* http://www.w3.org/ns/dcat#Dataset
+
+That will add or modify the `dcterms:created` and `dcterms:modified` properties, and:
+
+* http://schema.org/Dataset
 * https://cube.link/Cube
 
+that will add or modify the `schema:dateCreated` and `schema:dateUpdated` properties.
+  
 ### Named Date Literals
 
 #### TIME_NOW

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,0 +1,82 @@
+
+# Metadata operation
+
+## Append
+
+Say you have a `dataset_description.ttl` file containing:
+
+```turtle
+<http://example.org/test> a <http://schema.org/Dataset> .
+```
+
+Then a step:
+
+```turtle
+@prefix p:    <https://pipeline.described.at/> .
+@prefix code: <https://code.described.at/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<attachMetadata>
+    a                  p:Step ;
+    rdfs:label         "Attach metadata" ;
+    code:implementedBy [ a         code:EcmaScriptModule ;
+                         code:link <node:barnard59-rdf/metadata.js#append> ] ;
+    code:arguments [
+					   code:name "input"; code:value "../../metadata/dataset_description.ttl"
+				   ],
+				   [
+					   code:name "dateCreated";
+					   code:value  "2020-05-30";
+				   ],
+				   [
+					   code:name "dateModified";
+					   code:value  "TIME_NOW";
+				   ] .
+
+```
+
+will append the contents of `dataset_description.ttl` to the stream, with new or updated `schema.dateModified` or `schema.dateCreated` properties.
+
+```turtle
+<http://example.org/test> <http://schema.org/dateModified> "2022-04-13T08:55:21.363Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.org/test> <http://schema.org/dateCreated> "2020-05-30"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+```
+
+### Parameters
+
+#### input
+
+The quads to append. Can be a file, a quad stream or an URL pointing to the resource.
+
+### Optional parameters
+
+#### basepath
+
+Sets the base path used to fetch the file.
+
+#### graph
+
+The namedgraph used for the incoming metadata quads.
+
+### Dataset Classes
+
+The operation updates subjects with a type that's a 'well known dataset class', currently:
+
+* http://rdfs.org/ns/void#Dataset
+* http://schema.org/Dataset,
+* http://www.w3.org/ns/dcat#Dataset,
+* https://cube.link/Cube
+
+### Named Date Literals
+
+#### TIME_NOW
+
+The current time
+
+#### TIME_FILE_CREATION
+
+The file creation time. Applies only to files
+
+#### TIME_FILE_MODIFICATION
+
+The file modification time. Applies only to files

--- a/lib/append.js
+++ b/lib/append.js
@@ -39,7 +39,7 @@ async function append ({
   if (!input) {
     throw new Error('Needs input as parameter (url or filename)')
   }
-  const basePath = this?.context?.basePath ? this.context.basePath : basepath
+  const basePath = this?.basePath ? this.basePath : basepath
 
   return new MetadataAppend(this, basePath, input, { graph, dateModified, dateCreated })
 }

--- a/lib/append.js
+++ b/lib/append.js
@@ -1,0 +1,47 @@
+import { Transform } from 'readable-stream'
+import { applyOptions } from './metadata/applyOptions.js'
+import { localFetch } from './localFetch/localFetch.js'
+
+class MetadataAppend extends Transform {
+  constructor (context, basePath, input, options) {
+    super({ objectMode: true })
+    this.context = context
+    this.basePath = basePath
+    this.input = input
+    this.options = options
+  }
+
+  _transform (chunk, encoding, callback) {
+    callback(null, chunk)
+  }
+
+  async _flush (callback) {
+    try {
+      const { quadStream, metadata } = await localFetch(this.input, this.basePath)
+      for (const quad of await applyOptions(quadStream, metadata, this.options)) {
+        this.push(quad)
+      }
+    } catch (err) {
+      this.destroy(err)
+    } finally {
+      callback()
+    }
+  }
+}
+
+async function append ({
+  input,
+  basepath,
+  dateModified = undefined,
+  dateCreated = undefined,
+  graph = undefined,
+} = {}) {
+  if (!input) {
+    throw new Error('Needs input as parameter (url or filename)')
+  }
+  const basePath = this?.context?.basePath ? this.context.basePath : basepath
+
+  return new MetadataAppend(this, basePath, input, { graph, dateModified, dateCreated })
+}
+
+export default append

--- a/lib/append.js
+++ b/lib/append.js
@@ -1,6 +1,6 @@
 import { Transform } from 'readable-stream'
-import { applyOptions } from './metadata/applyOptions.js'
 import { localFetch } from './localFetch/localFetch.js'
+import { applyOptions } from './metadata/applyOptions.js'
 
 class MetadataAppend extends Transform {
   constructor (context, basePath, input, options) {
@@ -34,7 +34,7 @@ async function append ({
   basepath,
   dateModified = undefined,
   dateCreated = undefined,
-  graph = undefined,
+  graph = undefined
 } = {}) {
   if (!input) {
     throw new Error('Needs input as parameter (url or filename)')

--- a/lib/cube/buildCubeShape/Cube.js
+++ b/lib/cube/buildCubeShape/Cube.js
@@ -4,7 +4,7 @@ import clownface from 'clownface'
 import rdf from 'rdf-ext'
 import cbdCopy from '../../cbdCopy.js'
 import Dimension from './Dimension.js'
-import * as ns from './namespaces.js'
+import * as ns from '../../namespaces.js'
 
 class Cube {
   constructor ({ metadata, observationSet, shape, term }) {

--- a/lib/cube/buildCubeShape/Cube.js
+++ b/lib/cube/buildCubeShape/Cube.js
@@ -3,8 +3,8 @@ import TermSet from '@rdfjs/term-set'
 import clownface from 'clownface'
 import rdf from 'rdf-ext'
 import cbdCopy from '../../cbdCopy.js'
-import Dimension from './Dimension.js'
 import * as ns from '../../namespaces.js'
+import Dimension from './Dimension.js'
 
 class Cube {
   constructor ({ metadata, observationSet, shape, term }) {

--- a/lib/cube/buildCubeShape/Dimension.js
+++ b/lib/cube/buildCubeShape/Dimension.js
@@ -4,7 +4,7 @@ import clownface from 'clownface'
 import rdf from 'rdf-ext'
 import { fromRdf } from 'rdf-literal'
 import cbdCopy from '../../cbdCopy.js'
-import * as ns from './namespaces.js'
+import * as ns from '../../namespaces.js'
 
 const datatypeParsers = new TermMap([
   [ns.xsd.byte, fromRdf],

--- a/lib/cube/buildCubeShape/index.js
+++ b/lib/cube/buildCubeShape/index.js
@@ -4,9 +4,9 @@ import clownface from 'clownface'
 import once from 'lodash/once.js'
 import $rdf from 'rdf-ext'
 import { Transform } from 'readable-stream'
+import * as ns from '../../namespaces.js'
 import urlJoin from '../../urlJoin.js'
 import Cube from './Cube.js'
-import * as ns from '../../namespaces.js'
 
 function defaultCube ({ observationSet }) {
   const observationSetIri = observationSet && observationSet.value

--- a/lib/cube/buildCubeShape/index.js
+++ b/lib/cube/buildCubeShape/index.js
@@ -2,11 +2,11 @@ import TermMap from '@rdfjs/term-map'
 import TermSet from '@rdfjs/term-set'
 import clownface from 'clownface'
 import once from 'lodash/once.js'
-import rdf from 'rdf-ext'
+import $rdf from 'rdf-ext'
 import { Transform } from 'readable-stream'
 import urlJoin from '../../urlJoin.js'
 import Cube from './Cube.js'
-import * as ns from './namespaces.js'
+import * as ns from '../../namespaces.js'
 
 function defaultCube ({ observationSet }) {
   const observationSetIri = observationSet && observationSet.value
@@ -15,7 +15,7 @@ function defaultCube ({ observationSet }) {
     return null
   }
 
-  return rdf.namedNode(urlJoin(observationSetIri, '..'))
+  return $rdf.namedNode(urlJoin(observationSetIri, '..'))
 }
 
 function defaultShape ({ term }) {
@@ -25,7 +25,7 @@ function defaultShape ({ term }) {
     return null
   }
 
-  return rdf.namedNode(urlJoin(cubeIri, 'shape'))
+  return $rdf.namedNode(urlJoin(cubeIri, 'shape'))
 }
 
 class CubeShapeBuilder extends Transform {
@@ -35,7 +35,7 @@ class CubeShapeBuilder extends Transform {
     this.options = {
       cubes: new TermMap(),
       cube: defaultCube,
-      excludeValuesOf: new TermSet(excludeValuesOf ? excludeValuesOf.map(v => rdf.namedNode(v)) : []),
+      excludeValuesOf: new TermSet(excludeValuesOf ? excludeValuesOf.map(v => $rdf.namedNode(v)) : []),
       metadataStream: metadata,
       shape: defaultShape
     }
@@ -45,9 +45,9 @@ class CubeShapeBuilder extends Transform {
 
   async _init () {
     if (this.options.metadataStream) {
-      this.options.metadata = await rdf.dataset().import(this.options.metadataStream)
+      this.options.metadata = await $rdf.dataset().import(this.options.metadataStream)
     } else {
-      this.options.metadata = rdf.dataset()
+      this.options.metadata = $rdf.dataset()
     }
   }
 
@@ -58,7 +58,7 @@ class CubeShapeBuilder extends Transform {
       return callback(err)
     }
 
-    const dataset = rdf.dataset([...chunk])
+    const dataset = $rdf.dataset([...chunk])
 
     const context = {
       dataset,

--- a/lib/localFetch/localFetch.js
+++ b/lib/localFetch/localFetch.js
@@ -1,0 +1,72 @@
+import fs from 'fs'
+import fsp from 'fs/promises'
+
+import { resolve } from 'path'
+import rdfFetch from '@rdfjs/fetch'
+import isStream, { isReadable } from 'isstream'
+import { getParserByExtension } from './lookupParser.js'
+
+function isReadableStream (arg) {
+  return isStream(arg) && isReadable(arg)
+}
+
+function isFileProtocol (url) {
+  return (url.protocol === 'file:')
+}
+
+function isHTTP (url) {
+  return (url.protocol === 'https:' || url.protocol === 'http:')
+}
+
+// Tries to fetch or read locally one file
+async function localFetch (
+  input,
+  basePath
+) {
+  if (!(input)) {
+    throw new Error('needs input filename or URL')
+  }
+
+  if (isReadableStream(input)) {
+    return { quadStream: input, metadata: {} }
+  }
+
+  if (typeof input !== 'string') {
+    throw new Error(`needs input filename or URL, got [${typeof input}]`)
+  }
+
+  const url = new URL(input, import.meta.url)
+  if (isHTTP(url)) {
+    const res = await rdfFetch(url)
+    return {
+      quadStream: await res.quadStream(),
+      metadata: {
+        uri: url
+      }
+    }
+  }
+
+  if (!isFileProtocol(new URL(input, import.meta.url))) {
+    throw new Error(`Could not load ${input}`)
+  }
+
+  const filePath = input.startsWith('file://') ? input : (basePath ? resolve(basePath, input) : input)
+
+  const filePathURL = new URL(filePath, import.meta.url)
+
+  const stream = fs.createReadStream(filePathURL)
+  const parser = getParserByExtension(filePath)
+  if (!parser) {
+    throw new Error(`No parser could be guessed for ${filePath}`)
+  }
+  const quadStream = await parser.import(stream)
+  return {
+    quadStream: quadStream,
+    metadata: {
+      stats: await fsp.lstat(filePathURL),
+      uri: filePathURL.toString()
+    }
+  }
+}
+
+export { localFetch }

--- a/lib/localFetch/lookupParser.js
+++ b/lib/localFetch/lookupParser.js
@@ -1,0 +1,11 @@
+import defaultFormats from '@rdfjs/formats-common'
+import mime from 'mime-types'
+
+function getParserByExtension (fileUrl) {
+  const mimeType = mime.lookup(fileUrl.toString())
+  return defaultFormats.parsers.get(mimeType)
+}
+
+export {
+  getParserByExtension
+}

--- a/lib/metadata/applyOptions.js
+++ b/lib/metadata/applyOptions.js
@@ -2,7 +2,7 @@ import TermSet from '@rdfjs/term-set'
 import rdf from 'rdf-ext'
 import * as ns from '../namespaces.js'
 import { xsd } from '../namespaces.js'
-import { wellKnownDatasetClasses } from './datasetClasses.js'
+import { wellKnownDatasetClasses, wellKnownDatasetClassesWithDcterms } from './datasetClasses.js'
 import { namedDateLiterals } from './namedDateLiterals.js'
 
 function subjectsWithDatasetType (dataset, classes) {
@@ -15,8 +15,8 @@ function subjectsWithDatasetType (dataset, classes) {
   return result
 }
 
-function updateOrInsert (dataset, predicate, object) {
-  const targetSubjects = subjectsWithDatasetType(dataset, wellKnownDatasetClasses)
+function updateOrInsert (dataset, datasetClasses, predicate, object) {
+  const targetSubjects = subjectsWithDatasetType(dataset, datasetClasses)
 
   // Remove existent
   dataset = dataset.filter(quad => {
@@ -48,12 +48,17 @@ async function applyOptions (quadStream, metadata = {}, options = {}) {
 
   // dateModified
   if (options.dateModified) {
-    dataset = updateOrInsert(dataset, ns.schema.dateModified, resolveNamedDate(options.dateModified, metadata))
+    const dateModifiedLiteral = resolveNamedDate(options.dateModified, metadata)
+
+    dataset = updateOrInsert(dataset, wellKnownDatasetClassesWithDcterms, ns.dcterms.modified, dateModifiedLiteral)
+    dataset = updateOrInsert(dataset, wellKnownDatasetClasses, ns.schema.dateModified, dateModifiedLiteral)
   }
 
   // dateCreated
   if (options.dateCreated) {
-    dataset = updateOrInsert(dataset, ns.schema.dateCreated, resolveNamedDate(options.dateCreated, metadata))
+    const dateCreatedLiteral = resolveNamedDate(options.dateCreated, metadata)
+    dataset = updateOrInsert(dataset, wellKnownDatasetClassesWithDcterms, ns.dcterms.created, dateCreatedLiteral)
+    dataset = updateOrInsert(dataset, wellKnownDatasetClasses, ns.schema.dateCreated, dateCreatedLiteral)
   }
 
   // Sets graph

--- a/lib/metadata/applyOptions.js
+++ b/lib/metadata/applyOptions.js
@@ -1,0 +1,68 @@
+import TermSet from '@rdfjs/term-set'
+import rdf from 'rdf-ext'
+import * as ns from '../namespaces.js'
+import { xsd } from '../namespaces.js'
+import { wellKnownDatasetClasses } from './datasetClasses.js'
+import { namedDateLiterals } from './namedDateLiterals.js'
+
+function subjectsWithDatasetType (dataset, classes) {
+  const result = new TermSet()
+  dataset
+    .filter(quad => (quad.predicate.equals(ns.rdf.type) && classes.has(quad.object)))
+    .forEach(quad => {
+      result.add(quad.subject)
+    })
+  return result
+}
+
+function updateOrInsert (dataset, predicate, object) {
+  const targetSubjects = subjectsWithDatasetType(dataset, wellKnownDatasetClasses)
+
+  // Remove existent
+  dataset = dataset.filter((quad) => {
+    return !(quad.predicate.equals(predicate) && targetSubjects.has(quad.subject))
+  })
+
+  // Append
+  for (const subject of targetSubjects) {
+    dataset.add(rdf.quad(subject, predicate, object))
+  }
+
+  return dataset
+}
+
+function toDateLiteral (item) {
+  return typeof item === 'string' ? rdf.literal(item, xsd.dateTime) : item
+}
+
+function toNamedNode (item) {
+  return typeof item === 'string' ? rdf.namedNode(item) : item
+}
+
+function resolveNamedDate (value, metadata) {
+  return namedDateLiterals.has(value) ? namedDateLiterals.get(value)(metadata) : toDateLiteral(value)
+}
+
+async function applyOptions (quadStream, metadata = {}, options = {}) {
+
+  let dataset = await rdf.dataset().import(quadStream)
+
+  // dateModified
+  if (options.dateModified) {
+    dataset = updateOrInsert(dataset, ns.schema.dateModified, resolveNamedDate(options.dateModified, metadata))
+  }
+
+  // dateCreated
+  if (options.dateCreated) {
+    dataset = updateOrInsert(dataset, ns.schema.dateCreated, resolveNamedDate(options.dateCreated, metadata))
+  }
+
+  // Sets graph
+  if (options.graph) {
+    dataset = dataset.map((quad) => rdf.quad(quad.subject, quad.predicate, quad.object, toNamedNode(options.graph)))
+  }
+
+  return dataset
+}
+
+export { applyOptions }

--- a/lib/metadata/applyOptions.js
+++ b/lib/metadata/applyOptions.js
@@ -19,7 +19,7 @@ function updateOrInsert (dataset, predicate, object) {
   const targetSubjects = subjectsWithDatasetType(dataset, wellKnownDatasetClasses)
 
   // Remove existent
-  dataset = dataset.filter((quad) => {
+  dataset = dataset.filter(quad => {
     return !(quad.predicate.equals(predicate) && targetSubjects.has(quad.subject))
   })
 
@@ -44,7 +44,6 @@ function resolveNamedDate (value, metadata) {
 }
 
 async function applyOptions (quadStream, metadata = {}, options = {}) {
-
   let dataset = await rdf.dataset().import(quadStream)
 
   // dateModified
@@ -59,7 +58,7 @@ async function applyOptions (quadStream, metadata = {}, options = {}) {
 
   // Sets graph
   if (options.graph) {
-    dataset = dataset.map((quad) => rdf.quad(quad.subject, quad.predicate, quad.object, toNamedNode(options.graph)))
+    dataset = dataset.map(quad => rdf.quad(quad.subject, quad.predicate, quad.object, toNamedNode(options.graph)))
   }
 
   return dataset

--- a/lib/metadata/datasetClasses.js
+++ b/lib/metadata/datasetClasses.js
@@ -1,0 +1,10 @@
+import TermSet from '@rdfjs/term-set'
+import * as ns from '../namespaces.js'
+
+const wellKnownDatasetClasses = new TermSet([
+  ns._void.Dataset,
+  ns.schema.Dataset,
+  ns.dcat.Dataset]
+)
+
+export { wellKnownDatasetClasses }

--- a/lib/metadata/datasetClasses.js
+++ b/lib/metadata/datasetClasses.js
@@ -2,11 +2,15 @@ import TermSet from '@rdfjs/term-set'
 import * as ns from '../namespaces.js'
 
 const wellKnownDatasetClasses = new TermSet([
-  ns._void.Dataset,
   ns.schema.Dataset,
-  ns.dcat.Dataset,
   ns.cube.Cube
 ]
 )
 
-export { wellKnownDatasetClasses }
+const wellKnownDatasetClassesWithDcterms = new TermSet([
+  ns._void.Dataset,
+  ns.dcat.Dataset
+]
+)
+
+export { wellKnownDatasetClasses, wellKnownDatasetClassesWithDcterms }

--- a/lib/metadata/datasetClasses.js
+++ b/lib/metadata/datasetClasses.js
@@ -2,11 +2,11 @@ import TermSet from '@rdfjs/term-set'
 import * as ns from '../namespaces.js'
 
 const wellKnownDatasetClasses = new TermSet([
-    ns._void.Dataset,
-    ns.schema.Dataset,
-    ns.dcat.Dataset,
-    ns.cube.Cube
-  ]
+  ns._void.Dataset,
+  ns.schema.Dataset,
+  ns.dcat.Dataset,
+  ns.cube.Cube
+]
 )
 
 export { wellKnownDatasetClasses }

--- a/lib/metadata/datasetClasses.js
+++ b/lib/metadata/datasetClasses.js
@@ -2,10 +2,11 @@ import TermSet from '@rdfjs/term-set'
 import * as ns from '../namespaces.js'
 
 const wellKnownDatasetClasses = new TermSet([
-  ns._void.Dataset,
-  ns.schema.Dataset,
-  ns.dcat.Dataset,
-  ns.cube.Cube]
+    ns._void.Dataset,
+    ns.schema.Dataset,
+    ns.dcat.Dataset,
+    ns.cube.Cube
+  ]
 )
 
 export { wellKnownDatasetClasses }

--- a/lib/metadata/datasetClasses.js
+++ b/lib/metadata/datasetClasses.js
@@ -4,7 +4,8 @@ import * as ns from '../namespaces.js'
 const wellKnownDatasetClasses = new TermSet([
   ns._void.Dataset,
   ns.schema.Dataset,
-  ns.dcat.Dataset]
+  ns.dcat.Dataset,
+  ns.cube.Cube]
 )
 
 export { wellKnownDatasetClasses }

--- a/lib/metadata/namedDateLiterals.js
+++ b/lib/metadata/namedDateLiterals.js
@@ -1,0 +1,24 @@
+import { xsd } from '../namespaces.js'
+import rdf from 'rdf-ext'
+
+const namedDateLiterals = new Map()
+
+namedDateLiterals.set('TIME_NOW', metadata => {
+  return rdf.literal((new Date()).toISOString(), xsd.dateTime)
+})
+
+namedDateLiterals.set('TIME_FILE_CREATION', metadata => {
+  if (!metadata?.stats?.birthtimeMs) {
+    throw new Error('No metadata.stats.birthtimeMs')
+  }
+  return rdf.literal((new Date(metadata.stats.birthtimeMs)).toISOString(), xsd.dateTime)
+})
+
+namedDateLiterals.set('TIME_FILE_MODIFICATION', metadata => {
+  if (!metadata?.stats?.mtimeMs) {
+    throw new Error('No metadata.stats.mtimeMs')
+  }
+  return rdf.literal((new Date(metadata.stats.mtimeMs)).toISOString(), xsd.dateTime)
+})
+
+export { namedDateLiterals }

--- a/lib/metadata/namedDateLiterals.js
+++ b/lib/metadata/namedDateLiterals.js
@@ -1,5 +1,5 @@
-import { xsd } from '../namespaces.js'
 import rdf from 'rdf-ext'
+import { xsd } from '../namespaces.js'
 
 const namedDateLiterals = new Map()
 

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -5,5 +5,8 @@ const rdf = namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
 const rdfs = namespace('http://www.w3.org/2000/01/rdf-schema#')
 const sh = namespace('http://www.w3.org/ns/shacl#')
 const xsd = namespace('http://www.w3.org/2001/XMLSchema#')
+const _void = namespace('http://rdfs.org/ns/void#')
+const dcat = namespace('http://www.w3.org/ns/dcat#')
+const schema = namespace('http://schema.org/')
 
-export { cube, rdf, rdfs, sh, xsd }
+export { cube, rdf, rdfs, sh, xsd, _void, dcat, schema }

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -8,5 +8,6 @@ const xsd = namespace('http://www.w3.org/2001/XMLSchema#')
 const _void = namespace('http://rdfs.org/ns/void#')
 const dcat = namespace('http://www.w3.org/ns/dcat#')
 const schema = namespace('http://schema.org/')
+const dcterms = namespace('http://purl.org/dc/terms/')
 
-export { cube, rdf, rdfs, sh, xsd, _void, dcat, schema }
+export { cube, rdf, rdfs, sh, xsd, _void, dcat, schema, dcterms }

--- a/manifest.ttl
+++ b/manifest.ttl
@@ -30,3 +30,10 @@
   code:implementedBy [ a code:EcmaScript;
     code:link <node:barnard59-rdf/setGraph.js#default>
   ].
+
+<metadata.js#append> a p:Operation, p:WritableObjectMode, p:ReadableObjectMode;
+  rdfs:label "Append metadata";
+  rdfs:comment "Fetches, updates and appends a metadata resource";
+  code:implementedBy [ a code:EcmaScript;
+                       code:link <node:barnard59-rdf/metadata.js#append>
+  ].

--- a/metadata.js
+++ b/metadata.js
@@ -1,0 +1,3 @@
+import append from './lib/append.js'
+
+export default append

--- a/metadata.js
+++ b/metadata.js
@@ -1,3 +1,3 @@
 import append from './lib/append.js'
 
-export default append
+export { append }

--- a/package.json
+++ b/package.json
@@ -20,29 +20,31 @@
   },
   "homepage": "https://github.com/zazuko/barnard59-rdf",
   "dependencies": {
+    "@rdfjs/fetch": "^3.0.0",
+    "@rdfjs/formats-common": "^2.2.0",
     "@rdfjs/namespace": "^1.1.0",
     "@rdfjs/term-map": "^1.0.0",
     "@rdfjs/term-set": "^1.0.1",
     "clownface": "^1.3.0",
+    "file-fetch": "^1.7.0",
     "lodash": "^4.17.21",
+    "mime-types": "^2.1.35",
+    "proto-fetch": "^1.0.0",
     "rdf-ext": "^1.3.2",
     "rdf-literal": "^1.3.0",
     "rdf-transform-triple-to-quad": "^1.0.2",
-    "readable-stream": "^3.6.0",
-    "@rdfjs/formats-common": "^2.2.0",
-    "mime-types": "^2.1.35",
-    "@rdfjs/fetch": "^3.0.0"
+    "readable-stream": "^3.6.0"
   },
   "devDependencies": {
     "@rdfjs/to-ntriples": "^1.0.2",
+    "assert-throws-async": "^3.0.0",
     "c8": "^7.7.3",
     "codecov": "^3.8.2",
     "get-stream": "^6.0.1",
     "isstream": "^0.1.2",
     "mocha": "^9.0.1",
-    "stricter-standard": "^0.2.0",
-    "assert-throws-async": "^3.0.0",
-    "nock": "^13.2.4"
+    "nock": "^13.2.4",
+    "stricter-standard": "^0.2.0"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "rdf-ext": "^1.3.2",
     "rdf-literal": "^1.3.0",
     "rdf-transform-triple-to-quad": "^1.0.2",
-    "readable-stream": "^3.6.0"
+    "readable-stream": "^3.6.0",
+    "@rdfjs/formats-common": "^2.2.0",
+    "mime-types": "^2.1.35",
+    "@rdfjs/fetch": "^3.0.0"
   },
   "devDependencies": {
     "@rdfjs/to-ntriples": "^1.0.2",
@@ -37,7 +40,9 @@
     "get-stream": "^6.0.1",
     "isstream": "^0.1.2",
     "mocha": "^9.0.1",
-    "stricter-standard": "^0.2.0"
+    "stricter-standard": "^0.2.0",
+    "assert-throws-async": "^3.0.0",
+    "nock": "^13.2.4"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnard59-rdf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "RDF support for Linked Data pipelines",
   "main": "index.js",
   "type": "module",

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -300,4 +300,88 @@ describe('File System: metadata.append', () => {
     strictEqual(result[3].predicate.value, schema.dateCreated.value)
     strictEqual(result[3].object.value === rdf.literal('2020-05-30').value, false)
   })
+
+  it('should use specified literal with dateModified (string)', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+    const metadata = [
+      rdf.quad(ex.subject1, rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), schema.Dataset),
+      rdf.quad(ex.subject1, schema.dateModified, rdf.literal('2020-05-30'))
+    ]
+    const step = await append({
+      input: Readable.from(metadata),
+      dateModified: '1999-12-31'
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 3)
+
+    strictEqual(result[2].predicate.value, schema.dateModified.value)
+    strictEqual(result[2].object.value, rdf.literal('1999-12-31').value)
+  })
+
+  it('should use specified literal with dateCreated (string)', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+    const metadata = [
+      rdf.quad(ex.subject1, rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), schema.Dataset),
+      rdf.quad(ex.subject1, schema.dateCreated, rdf.literal('2020-05-30'))
+    ]
+    const step = await append({
+      input: Readable.from(metadata),
+      dateCreated: '1999-12-31'
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 3)
+
+    strictEqual(result[2].predicate.value, schema.dateCreated.value)
+    strictEqual(result[2].object.value, rdf.literal('1999-12-31').value)
+  })
+
+  it('should use specified literal with dateModified', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+    const metadata = [
+      rdf.quad(ex.subject1, rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), schema.Dataset),
+      rdf.quad(ex.subject1, schema.dateModified, rdf.literal('2020-05-30'))
+    ]
+    const step = await append({
+      input: Readable.from(metadata),
+      dateModified: rdf.literal('1999-12-31', xsd.dateTime)
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 3)
+
+    strictEqual(result[2].predicate.value, schema.dateModified.value)
+    strictEqual(result[2].object.value, rdf.literal('1999-12-31').value)
+  })
+
+  it('should use specified literal with dateCreated', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+    const metadata = [
+      rdf.quad(ex.subject1, rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), schema.Dataset),
+      rdf.quad(ex.subject1, schema.dateCreated, rdf.literal('2020-05-30'))
+    ]
+    const step = await append({
+      input: Readable.from(metadata),
+      dateCreated: rdf.literal('1999-12-31', xsd.dateTime)
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 3)
+
+    strictEqual(result[2].predicate.value, schema.dateCreated.value)
+    strictEqual(result[2].object.value, rdf.literal('1999-12-31').value)
+  })
 })

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -1,7 +1,9 @@
 import { equal, strictEqual } from 'assert'
 import fs from 'fs'
 import fsp from 'fs/promises'
+import { fileURLToPath } from 'url'
 import defaultFormats from '@rdfjs/formats-common'
+import namespace from '@rdfjs/namespace'
 import assertThrows from 'assert-throws-async'
 import getStream from 'get-stream'
 import { isDuplex } from 'isstream'
@@ -11,8 +13,6 @@ import rdf from 'rdf-ext'
 import { Readable } from 'readable-stream'
 import append from '../lib/append.js'
 import { schema, xsd } from '../lib/namespaces.js'
-import namespace from '@rdfjs/namespace'
-import { fileURLToPath } from 'url'
 
 const dataPath = './support/dataset.ttl'
 new URL(dataPath, import.meta.url).toString()
@@ -181,7 +181,6 @@ describe('File System: metadata.append', () => {
 
     strictEqual(result[5].predicate.value, schema.dateCreated.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
-
   })
 
   it('should use resolved literal TIME_FILE_CREATION with dateModified', async () => {
@@ -205,7 +204,6 @@ describe('File System: metadata.append', () => {
 
     strictEqual(result[5].predicate.value, schema.dateModified.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
-
   })
 
   it('should use resolved literal TIME_FILE_MODIFICATION with dateCreated', async () => {
@@ -228,7 +226,6 @@ describe('File System: metadata.append', () => {
 
     strictEqual(result[5].predicate.value, schema.dateCreated.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
-
   })
 
   it('should use resolved literal TIME_FILE_MODIFICATION with dateModified', async () => {
@@ -252,7 +249,6 @@ describe('File System: metadata.append', () => {
 
     strictEqual(result[5].predicate.value, schema.dateModified.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
-
   })
 
   it('should use resolved literal TIME_NOW with dateModified', async () => {
@@ -278,7 +274,6 @@ describe('File System: metadata.append', () => {
 
     strictEqual(result[3].predicate.value, schema.dateModified.value)
     strictEqual(result[3].object.value === rdf.literal('2020-05-30').value, false)
-
   })
 
   it('should use resolved literal TIME_NOW with dateCreated', async () => {
@@ -304,7 +299,5 @@ describe('File System: metadata.append', () => {
 
     strictEqual(result[3].predicate.value, schema.dateCreated.value)
     strictEqual(result[3].object.value === rdf.literal('2020-05-30').value, false)
-
   })
-
 })

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -1,0 +1,310 @@
+import { equal, strictEqual } from 'assert'
+import fs from 'fs'
+import fsp from 'fs/promises'
+import defaultFormats from '@rdfjs/formats-common'
+import assertThrows from 'assert-throws-async'
+import getStream from 'get-stream'
+import { isDuplex } from 'isstream'
+import { describe, it } from 'mocha'
+import nock from 'nock'
+import rdf from 'rdf-ext'
+import { Readable } from 'readable-stream'
+import append from '../lib/append.js'
+import { schema, xsd } from '../lib/namespaces.js'
+import namespace from '@rdfjs/namespace'
+import { fileURLToPath } from 'url'
+
+const dataPath = './support/dataset.ttl'
+new URL(dataPath, import.meta.url).toString()
+
+const metadataPath = './support/dataset_description.ttl'
+new URL(metadataPath, import.meta.url).toString()
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+
+const ex = namespace('http://example.org/')
+
+async function getRDFDataset (filePath) {
+  return rdf.dataset().import(getRDFStream(filePath))
+}
+
+function getRDFStream (filePath) {
+  const stream = fs.createReadStream(new URL(filePath, import.meta.url))
+  const parser = defaultFormats.parsers.get('text/turtle')
+  return parser.import(stream)
+}
+
+async function applyStep (transform) {
+  const initial = await getRDFDataset(dataPath)
+  const stream = getRDFStream(dataPath).pipe(transform)
+  const final = rdf.dataset(await getStream.array(stream))
+  return { initial, final }
+}
+
+describe('metadata.append', () => {
+  it('should be a factory', () => {
+    strictEqual(typeof append, 'function')
+  })
+
+  it('should throw an error if no argument is given', async () => {
+    await assertThrows(async () => {
+      await append()
+    }, Error, /Needs input as parameter/)
+  })
+
+  it('should return a duplex stream with a stream metadata parameter', async () => {
+    const step = await append({
+      input: getRDFStream(metadataPath)
+    })
+    strictEqual(isDuplex(step), true)
+  })
+
+  it('should return a duplex stream with a path (string) metadata parameter', async () => {
+    const step = await append({
+      input: metadataPath
+    })
+    strictEqual(isDuplex(step), true)
+  })
+
+  it('should return a duplex stream with an URL pointing to a public resource', async () => {
+    // Mocking a remote file.
+    const fileStr = fs.readFileSync(new URL(metadataPath, import.meta.url), 'utf8')
+    nock('https://example.com')
+      .get('/metadata.ttl')
+      .reply(200, fileStr, { 'content-type': 'text/turtle' })
+
+    const stream = await append({
+      input: 'https://example.com/metadata.ttl'
+    })
+    strictEqual(isDuplex(stream), true)
+  })
+
+  it('should append data and metadata with default values', async () => {
+    const all = rdf.dataset()
+    all.addAll(await getRDFDataset(dataPath))
+    all.addAll(await getRDFDataset(metadataPath))
+
+    const step = await append({
+      input: getRDFStream(metadataPath)
+    })
+    const { final } = await applyStep(step)
+
+    equal(
+      final.toCanonical(),
+      all.toCanonical(), 'appended quads not as expected'
+    )
+  })
+
+  it('should append data and metadata with default values, and path as string', async () => {
+    const all = rdf.dataset()
+    all.addAll(await getRDFDataset(dataPath))
+    all.addAll(await getRDFDataset(metadataPath))
+
+    const step = await append({
+      input: metadataPath,
+      basepath: __dirname
+    })
+    const { final } = await applyStep(step)
+
+    equal(
+      final.toCanonical(),
+      all.toCanonical(), 'appended quads not as expected'
+    )
+  })
+
+  it('should append data with the specified graph', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+
+    const metadata = [
+      rdf.quad(ex.subject1, ex.predicate1, ex.object1, ex.graph1),
+      rdf.quad(ex.subject2, ex.predicate2, ex.object2, ex.graph2)
+    ]
+
+    const graphString = 'http://example.org/metadata'
+    const graph = rdf.namedNode(graphString)
+
+    const step = await append({
+      input: Readable.from(metadata),
+      graph: graphString
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 3)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(metadata[0]), false)
+    strictEqual(result[2].equals(metadata[1]), false)
+
+    strictEqual(result[1].graph.value, graph.value)
+    strictEqual(result[2].graph.value, graph.value)
+  })
+
+  it('fails at unknown protocol', async () => {
+    await assertThrows(async () => {
+      const step = await append({
+        input: 'unknown::protocol'
+      })
+      await applyStep(step)
+    }, Error, /Could not load unknown::protocol/)
+  })
+
+  it('fails at file not found', async () => {
+    await assertThrows(async () => {
+      const step = await append({
+        input: 'file:///not/found.ttl'
+      })
+      await applyStep(step)
+    }, Error, /ENOENT: no such file or directory/)
+  })
+})
+
+describe('File System: metadata.append', () => {
+  it('should use resolved literal TIME_FILE_CREATION with dateCreated', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+
+    const step = await append({
+      input: metadataPath,
+      basepath: __dirname,
+      dateCreated: 'TIME_FILE_CREATION'
+    })
+
+    const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
+    const result = await getStream.array(Readable.from(data).pipe(step))
+    strictEqual(result.length, 6)
+
+    strictEqual(result[4].predicate.value, schema.dateModified.value)
+    strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
+
+    strictEqual(result[5].predicate.value, schema.dateCreated.value)
+    strictEqual(result[5].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
+
+  })
+
+  it('should use resolved literal TIME_FILE_CREATION with dateModified', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+
+    const step = await append({
+      input: metadataPath,
+      basepath: __dirname,
+      dateModified: 'TIME_FILE_CREATION'
+    })
+
+    const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 6)
+
+    strictEqual(result[4].predicate.value, schema.dateCreated.value)
+    strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
+
+    strictEqual(result[5].predicate.value, schema.dateModified.value)
+    strictEqual(result[5].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
+
+  })
+
+  it('should use resolved literal TIME_FILE_MODIFICATION with dateCreated', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+
+    const step = await append({
+      input: metadataPath,
+      basepath: __dirname,
+      dateCreated: 'TIME_FILE_MODIFICATION'
+    })
+
+    const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
+    const result = await getStream.array(Readable.from(data).pipe(step))
+    strictEqual(result.length, 6)
+
+    strictEqual(result[4].predicate.value, schema.dateModified.value)
+    strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
+
+    strictEqual(result[5].predicate.value, schema.dateCreated.value)
+    strictEqual(result[5].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
+
+  })
+
+  it('should use resolved literal TIME_FILE_MODIFICATION with dateModified', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+
+    const step = await append({
+      input: metadataPath,
+      basepath: __dirname,
+      dateModified: 'TIME_FILE_MODIFICATION'
+    })
+
+    const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 6)
+
+    strictEqual(result[4].predicate.value, schema.dateCreated.value)
+    strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
+
+    strictEqual(result[5].predicate.value, schema.dateModified.value)
+    strictEqual(result[5].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
+
+  })
+
+  it('should use resolved literal TIME_NOW with dateModified', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+    const metadata = [
+      rdf.quad(ex.subject1, rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), schema.Dataset),
+      rdf.quad(ex.subject1, schema.dateCreated, rdf.literal('2020-05-30')),
+      rdf.quad(ex.subject1, schema.dateModified, rdf.literal('2020-05-30'))
+    ]
+    const step = await append({
+      input: Readable.from(metadata),
+      dateModified: 'TIME_NOW'
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 4)
+
+    strictEqual(result[2].predicate.value, schema.dateCreated.value)
+    strictEqual(result[2].object.value, rdf.literal('2020-05-30').value)
+
+    strictEqual(result[3].predicate.value, schema.dateModified.value)
+    strictEqual(result[3].object.value === rdf.literal('2020-05-30').value, false)
+
+  })
+
+  it('should use resolved literal TIME_NOW with dateCreated', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ex.predicate0, ex.object0, ex.graph0)
+    ]
+    const metadata = [
+      rdf.quad(ex.subject1, rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), schema.Dataset),
+      rdf.quad(ex.subject1, schema.dateCreated, rdf.literal('2020-05-30')),
+      rdf.quad(ex.subject1, schema.dateModified, rdf.literal('2020-05-30'))
+    ]
+    const step = await append({
+      input: Readable.from(metadata),
+      dateCreated: 'TIME_NOW'
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    strictEqual(result.length, 4)
+
+    strictEqual(result[2].predicate.value, schema.dateModified.value)
+    strictEqual(result[2].object.value, rdf.literal('2020-05-30').value)
+
+    strictEqual(result[3].predicate.value, schema.dateCreated.value)
+    strictEqual(result[3].object.value === rdf.literal('2020-05-30').value, false)
+
+  })
+
+})

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -12,7 +12,7 @@ import nock from 'nock'
 import rdf from 'rdf-ext'
 import { Readable } from 'readable-stream'
 import append from '../lib/append.js'
-import { schema, xsd } from '../lib/namespaces.js'
+import { schema, xsd, dcterms } from '../lib/namespaces.js'
 
 const dataPath = './support/dataset.ttl'
 new URL(dataPath, import.meta.url).toString()
@@ -174,13 +174,16 @@ describe('File System: metadata.append', () => {
 
     const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
     const result = await getStream.array(Readable.from(data).pipe(step))
-    strictEqual(result.length, 6)
+    strictEqual(result.length, 7)
 
     strictEqual(result[4].predicate.value, schema.dateModified.value)
     strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
 
-    strictEqual(result[5].predicate.value, schema.dateCreated.value)
+    strictEqual(result[5].predicate.value, dcterms.created.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
+
+    strictEqual(result[6].predicate.value, schema.dateCreated.value)
+    strictEqual(result[6].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
   })
 
   it('should use resolved literal TIME_FILE_CREATION with dateModified', async () => {
@@ -197,13 +200,16 @@ describe('File System: metadata.append', () => {
     const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
     const result = await getStream.array(Readable.from(data).pipe(step))
 
-    strictEqual(result.length, 6)
+    strictEqual(result.length, 7)
 
     strictEqual(result[4].predicate.value, schema.dateCreated.value)
     strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
 
-    strictEqual(result[5].predicate.value, schema.dateModified.value)
+    strictEqual(result[5].predicate.value, dcterms.modified.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
+
+    strictEqual(result[6].predicate.value, schema.dateModified.value)
+    strictEqual(result[6].object.value, rdf.literal((new Date(stats.birthtimeMs)).toISOString(), xsd.dateTime).value)
   })
 
   it('should use resolved literal TIME_FILE_MODIFICATION with dateCreated', async () => {
@@ -219,13 +225,16 @@ describe('File System: metadata.append', () => {
 
     const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
     const result = await getStream.array(Readable.from(data).pipe(step))
-    strictEqual(result.length, 6)
+    strictEqual(result.length, 7)
 
     strictEqual(result[4].predicate.value, schema.dateModified.value)
     strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
 
-    strictEqual(result[5].predicate.value, schema.dateCreated.value)
+    strictEqual(result[5].predicate.value, dcterms.created.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
+
+    strictEqual(result[6].predicate.value, schema.dateCreated.value)
+    strictEqual(result[6].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
   })
 
   it('should use resolved literal TIME_FILE_MODIFICATION with dateModified', async () => {
@@ -242,13 +251,16 @@ describe('File System: metadata.append', () => {
     const stats = await fsp.lstat(new URL(metadataPath, import.meta.url))
     const result = await getStream.array(Readable.from(data).pipe(step))
 
-    strictEqual(result.length, 6)
+    strictEqual(result.length, 7)
 
     strictEqual(result[4].predicate.value, schema.dateCreated.value)
     strictEqual(result[4].object.value, rdf.literal('2020-05-30').value)
 
-    strictEqual(result[5].predicate.value, schema.dateModified.value)
+    strictEqual(result[5].predicate.value, dcterms.modified.value)
     strictEqual(result[5].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
+
+    strictEqual(result[6].predicate.value, schema.dateModified.value)
+    strictEqual(result[6].object.value, rdf.literal((new Date(stats.mtimeMs)).toISOString(), xsd.dateTime).value)
   })
 
   it('should use resolved literal TIME_NOW with dateModified', async () => {

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -147,7 +147,7 @@ describe('metadata.append', () => {
         input: 'unknown::protocol'
       })
       await applyStep(step)
-    }, Error, /Could not load unknown::protocol/)
+    }, Error, /unknown protocol/)
   })
 
   it('fails at file not found', async () => {

--- a/test/localFetch/localFetch.test.js
+++ b/test/localFetch/localFetch.test.js
@@ -104,6 +104,6 @@ describe('metadata.lfetch', () => {
   it('fails at unknown protocol', async () => {
     await assertThrows(async () => {
       await localFetch('unknown::protocol')
-    }, Error, /Could not load unknown::protocol/)
+    }, Error, /unknown protocol/)
   })
 })

--- a/test/localFetch/localFetch.test.js
+++ b/test/localFetch/localFetch.test.js
@@ -1,0 +1,109 @@
+import { equal, strictEqual } from 'assert'
+import fs from 'fs'
+import { resolve } from 'path'
+import defaultFormats from '@rdfjs/formats-common'
+import assertThrows from 'assert-throws-async'
+import { describe, it } from 'mocha'
+import nock from 'nock'
+import rdf from 'rdf-ext'
+import { localFetch } from '../../lib/localFetch/localFetch.js'
+
+const datasetPath = '../support/dataset.ttl'
+const datasetAbsolutePath = new URL(datasetPath, import.meta.url).toString()
+
+async function getRDFDataset (filePath) {
+  return rdf.dataset().import(getRDFStream(filePath))
+}
+
+function getRDFStream (filePath) {
+  const stream = fs.createReadStream(new URL(filePath, import.meta.url))
+  const parser = defaultFormats.parsers.get('text/turtle')
+  return parser.import(stream)
+}
+
+describe('metadata.lfetch', () => {
+  it('should be a function', () => {
+    strictEqual(typeof localFetch, 'function')
+  })
+
+  it('should throw an error if no input is given', async () => {
+    await assertThrows(async () => {
+      await localFetch()
+    }, Error, /needs input filename or URL/)
+  })
+
+  it('should throw an error if no valid input is given', async () => {
+    await assertThrows(async () => {
+      await localFetch({ not: 'this' })
+    }, Error, /needs input filename or URL, got /)
+  })
+
+  it('with defaults, should get the same dataset', async () => {
+    const expected = await getRDFDataset(datasetPath)
+    const { quadStream } = await localFetch(getRDFStream(datasetPath))
+    const actual = await rdf.dataset().import(quadStream)
+    equal(expected.equals(actual), true)
+  })
+
+  it('with filename and base, should get the same dataset', async () => {
+    const expected = await getRDFDataset(datasetPath)
+    const { quadStream } = await localFetch(datasetPath, resolve('./test/ldfetch'))
+    const actual = await rdf.dataset().import(quadStream)
+
+    equal(expected.equals(actual), true)
+  })
+
+  it('with absolute filename, should get the same dataset', async () => {
+    const expected = await getRDFDataset(datasetPath)
+    const { quadStream } = await localFetch(datasetAbsolutePath)
+    const actual = await rdf.dataset().import(quadStream)
+
+    equal(expected.equals(actual), true)
+  })
+
+  it('with absolute filename, should ignore basePath and get the same dataset', async () => {
+    const expected = await getRDFDataset(datasetPath)
+    const { quadStream } = await localFetch(datasetAbsolutePath, '/unknown/')
+    const actual = await rdf.dataset().import(quadStream)
+
+    equal(expected.equals(actual), true)
+  })
+
+  it('fails at file not found', async () => {
+    await assertThrows(async () => {
+      await localFetch('file:///not/found.ttl')
+    }, Error, /ENOENT: no such file or directory/)
+  })
+
+  it('fails if not string', async () => {
+    await assertThrows(async () => {
+      await localFetch(['a', 'b'])
+    }, Error, /needs input filename or URL, got \[object\]/)
+  })
+
+  it('should get a dataset from URL pointing to a public resource', async () => {
+    // Mocking a remote file.
+    const fileStr = fs.readFileSync(new URL(datasetPath, import.meta.url), 'utf8')
+    nock('https://example.com')
+      .get('/metadata.ttl')
+      .reply(200, fileStr, { 'content-type': 'text/turtle' })
+
+    const expected = await getRDFDataset(datasetPath)
+    const { quadStream } = await localFetch('https://example.com/metadata.ttl')
+    const actual = await rdf.dataset().import(quadStream)
+
+    equal(expected.equals(actual), true)
+  })
+
+  it('fails at unknown file extension', async () => {
+    await assertThrows(async () => {
+      await localFetch(new URL('../support/file.unknown.extension', import.meta.url).toString())
+    }, Error, /No parser could be guessed for/)
+  })
+
+  it('fails at unknown protocol', async () => {
+    await assertThrows(async () => {
+      await localFetch('unknown::protocol')
+    }, Error, /Could not load unknown::protocol/)
+  })
+})

--- a/test/localFetch/lookupParser.test.js
+++ b/test/localFetch/lookupParser.test.js
@@ -1,0 +1,38 @@
+import { strictEqual } from 'assert'
+import { describe, it } from 'mocha'
+import { getParserByExtension } from '../../lib/localFetch/lookupParser.js'
+
+describe('metadata.lfetch.lookupParser', () => {
+  it('should be a function', () => {
+    strictEqual(typeof getParserByExtension, 'function')
+  })
+
+  it('should return a parser for well-known RDF extensions', async () => {
+    const rdfExtensions = [
+      'jsonld',
+      'trig',
+      'nq',
+      'nt',
+      'n3',
+      'ttl',
+      'rdf'
+    ]
+
+    rdfExtensions.forEach(extension => {
+      const parser = getParserByExtension(`/file.${extension}`)
+      strictEqual(parser !== null, true, `Should get a parser for extension ${extension}`)
+    })
+  })
+
+  it('should return undefined for non standard RDF extensions', async () => {
+    const nonRdfExtensions = [
+      'xml',
+      'turtle'
+    ]
+
+    nonRdfExtensions.forEach(extension => {
+      const parser = getParserByExtension(`/file.${extension}`)
+      strictEqual(parser === undefined, true, `Should not get a parser for extension ${extension}`)
+    })
+  })
+})

--- a/test/metadata/applyOptions.test.js
+++ b/test/metadata/applyOptions.test.js
@@ -65,6 +65,28 @@ describe('applyOptions', () => {
     strictEqual(result[1].equals(rdf.quad(ex.subject0, ns.schema.dateCreated, rdf.literal('1999-12-31', xsd.dateTime))), true)
   })
 
+  it('should update or append dcterms:created for known classes', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.dcat.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.dcterms.created, rdf.literal('Not me'), ex.graph0),
+      rdf.quad(ex.subject1, ns.rdf.type, ex.type1, ex.graph0),
+      rdf.quad(ex.subject3, ns.rdf.type, ns.dcat.Dataset, ex.graph0)
+    ]
+
+    const options = {
+      dateCreated: rdf.literal('1999-12-31', xsd.dateTime)
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 5)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(data[2]), true)
+    strictEqual(result[2].equals(data[3]), true)
+    strictEqual(result[3].equals(rdf.quad(ex.subject0, ns.dcterms.created, rdf.literal('1999-12-31', xsd.dateTime))), true)
+    strictEqual(result[4].equals(rdf.quad(ex.subject3, ns.dcterms.created, rdf.literal('1999-12-31', xsd.dateTime))), true)
+  })
+
   it('should update or append schema:dateModified for known classes', async () => {
     const data = [
       rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
@@ -85,6 +107,47 @@ describe('applyOptions', () => {
     strictEqual(result[2].equals(data[3]), true)
     strictEqual(result[3].equals(rdf.quad(ex.subject0, ns.schema.dateModified, rdf.literal('1999-12-31', xsd.dateTime))), true)
     strictEqual(result[4].equals(rdf.quad(ex.subject3, ns.schema.dateModified, rdf.literal('1999-12-31', xsd.dateTime))), true)
+  })
+
+  it('should update or append dcterms:modified for known classes', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.dcat.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.dcterms.modified, rdf.literal('Not me'), ex.graph0),
+      rdf.quad(ex.subject1, ns.rdf.type, ex.type1, ex.graph0),
+      rdf.quad(ex.subject3, ns.rdf.type, ns.dcat.Dataset, ex.graph0)
+    ]
+
+    const options = {
+      dateModified: rdf.literal('1999-12-31', xsd.dateTime)
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 5)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(data[2]), true)
+    strictEqual(result[2].equals(data[3]), true)
+    strictEqual(result[3].equals(rdf.quad(ex.subject0, ns.dcterms.modified, rdf.literal('1999-12-31', xsd.dateTime))), true)
+    strictEqual(result[4].equals(rdf.quad(ex.subject3, ns.dcterms.modified, rdf.literal('1999-12-31', xsd.dateTime))), true)
+  })
+
+  it('should update or append both dcterms:modified and schema:modified for known classes', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.dcat.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1)
+    ]
+
+    const options = {
+      dateModified: rdf.literal('1999-12-31', xsd.dateTime)
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 4)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(data[1]), true)
+    strictEqual(result[2].equals(rdf.quad(ex.subject0, ns.dcterms.modified, rdf.literal('1999-12-31', xsd.dateTime))), true)
+    strictEqual(result[3].equals(rdf.quad(ex.subject0, ns.schema.dateModified, rdf.literal('1999-12-31', xsd.dateTime))), true)
   })
 
   it('should update or append schema:dateModified for known (string)', async () => {

--- a/test/metadata/applyOptions.test.js
+++ b/test/metadata/applyOptions.test.js
@@ -51,7 +51,7 @@ describe('applyOptions', () => {
 
   it('should update or append schema:dateCreated for known classes (string)', async () => {
     const data = [
-      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1)
     ]
 
     const options = {
@@ -89,7 +89,7 @@ describe('applyOptions', () => {
 
   it('should update or append schema:dateModified for known (string)', async () => {
     const data = [
-      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1)
     ]
 
     const options = {
@@ -102,7 +102,6 @@ describe('applyOptions', () => {
     strictEqual(result[0].equals(data[0]), true)
     strictEqual(result[1].equals(rdf.quad(ex.subject0, ns.schema.dateModified, rdf.literal('1999-12-31', xsd.dateTime))), true)
   })
-
 
   it('should set the corresponding graph', async () => {
     const data = [
@@ -125,16 +124,15 @@ describe('applyOptions', () => {
     strictEqual(result[2].graph.equals(ex.graph2), true)
     strictEqual(result[3].graph.equals(ex.graph2), true)
     strictEqual(result[4].graph.equals(ex.graph2), true)
-
   })
 
   it('should set the corresponding graph (string)', async () => {
     const data = [
-      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1)
     ]
 
     const options = {
-      graph: ex.graph2.value,
+      graph: ex.graph2.value
     }
     const quadStream = Readable.from(data)
     const result = [...await applyOptions(quadStream, {}, options)]
@@ -142,5 +140,4 @@ describe('applyOptions', () => {
     strictEqual(result.length, 1)
     strictEqual(result[0].graph.equals(ex.graph2), true)
   })
-
 })

--- a/test/metadata/applyOptions.test.js
+++ b/test/metadata/applyOptions.test.js
@@ -1,0 +1,146 @@
+import { strictEqual } from 'assert'
+import namespace from '@rdfjs/namespace'
+import { describe, it } from 'mocha'
+import rdf from 'rdf-ext'
+import { Readable } from 'readable-stream'
+import { applyOptions } from '../../lib/metadata/applyOptions.js'
+import * as ns from '../../lib/namespaces.js'
+import { xsd } from '../../lib/namespaces.js'
+
+const ex = namespace('http://example.org/')
+
+describe('applyOptions', () => {
+  it('should be a function', () => {
+    strictEqual(typeof applyOptions, 'function')
+  })
+
+  it('should return the same data if no options given', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ex.type0, ex.graph1)
+    ]
+
+    const options = {}
+    const quadStream = Readable.from(data, options)
+    const result = [...await applyOptions(quadStream)]
+
+    strictEqual(result.length, 1)
+    strictEqual(result[0].equals(data[0]), true)
+  })
+
+  it('should update or append schema:dateCreated for known classes', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.schema.dateCreated, rdf.literal('Not me'), ex.graph0),
+      rdf.quad(ex.subject1, ns.rdf.type, ex.type1, ex.graph0),
+      rdf.quad(ex.subject3, ns.rdf.type, ns.schema.Dataset, ex.graph0)
+    ]
+
+    const options = {
+      dateCreated: rdf.literal('1999-12-31', xsd.dateTime)
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 5)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(data[2]), true)
+    strictEqual(result[2].equals(data[3]), true)
+    strictEqual(result[3].equals(rdf.quad(ex.subject0, ns.schema.dateCreated, rdf.literal('1999-12-31', xsd.dateTime))), true)
+    strictEqual(result[4].equals(rdf.quad(ex.subject3, ns.schema.dateCreated, rdf.literal('1999-12-31', xsd.dateTime))), true)
+  })
+
+  it('should update or append schema:dateCreated for known classes (string)', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+    ]
+
+    const options = {
+      dateCreated: rdf.literal('1999-12-31', xsd.dateTime).toString()
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 2)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(rdf.quad(ex.subject0, ns.schema.dateCreated, rdf.literal('1999-12-31', xsd.dateTime))), true)
+  })
+
+  it('should update or append schema:dateModified for known classes', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.schema.dateModified, rdf.literal('Not me'), ex.graph0),
+      rdf.quad(ex.subject1, ns.rdf.type, ex.type1, ex.graph0),
+      rdf.quad(ex.subject3, ns.rdf.type, ns.schema.Dataset, ex.graph0)
+    ]
+
+    const options = {
+      dateModified: rdf.literal('1999-12-31', xsd.dateTime)
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 5)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(data[2]), true)
+    strictEqual(result[2].equals(data[3]), true)
+    strictEqual(result[3].equals(rdf.quad(ex.subject0, ns.schema.dateModified, rdf.literal('1999-12-31', xsd.dateTime))), true)
+    strictEqual(result[4].equals(rdf.quad(ex.subject3, ns.schema.dateModified, rdf.literal('1999-12-31', xsd.dateTime))), true)
+  })
+
+  it('should update or append schema:dateModified for known (string)', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+    ]
+
+    const options = {
+      dateModified: rdf.literal('1999-12-31', xsd.dateTime).toString()
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 2)
+    strictEqual(result[0].equals(data[0]), true)
+    strictEqual(result[1].equals(rdf.quad(ex.subject0, ns.schema.dateModified, rdf.literal('1999-12-31', xsd.dateTime))), true)
+  })
+
+
+  it('should set the corresponding graph', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+      rdf.quad(ex.subject0, ns.schema.dateModified, rdf.literal('Not me'), ex.graph0),
+      rdf.quad(ex.subject1, ns.rdf.type, ex.type1, ex.graph0),
+      rdf.quad(ex.subject3, ns.rdf.type, ns.schema.Dataset, ex.graph0)
+    ]
+
+    const options = {
+      graph: ex.graph2,
+      dateModified: rdf.literal('1999-12-31', xsd.dateTime)
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 5)
+    strictEqual(result[0].graph.equals(ex.graph2), true)
+    strictEqual(result[1].graph.equals(ex.graph2), true)
+    strictEqual(result[2].graph.equals(ex.graph2), true)
+    strictEqual(result[3].graph.equals(ex.graph2), true)
+    strictEqual(result[4].graph.equals(ex.graph2), true)
+
+  })
+
+  it('should set the corresponding graph (string)', async () => {
+    const data = [
+      rdf.quad(ex.subject0, ns.rdf.type, ns.schema.Dataset, ex.graph1),
+    ]
+
+    const options = {
+      graph: ex.graph2.value,
+    }
+    const quadStream = Readable.from(data)
+    const result = [...await applyOptions(quadStream, {}, options)]
+
+    strictEqual(result.length, 1)
+    strictEqual(result[0].graph.equals(ex.graph2), true)
+  })
+
+})

--- a/test/support/dataset.ttl
+++ b/test/support/dataset.ttl
@@ -1,0 +1,8 @@
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <http://schema.org/> .
+
+<https://example.com/John-Doe>
+    a                   <http://schema.org/Person> ;
+    schema:dateModified "2020-05-30"^^xsd:date .

--- a/test/support/dataset_description.ttl
+++ b/test/support/dataset_description.ttl
@@ -1,0 +1,36 @@
+BASE <http://example.org/>
+PREFIX void:   <http://rdfs.org/ns/void#>
+PREFIX dcat:   <http://www.w3.org/ns/dcat#>
+
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX schema: <http://schema.org/>
+PREFIX wd:     <http://www.wikidata.org/entity/>
+PREFIX org:    <https://ld.admin.ch/org/>
+
+
+<>
+    schema:dataset      <data> ;
+    foaf:topic          <data> ;
+    <dateSomethingElse> "2001-05-30"^^xsd:date
+.
+
+<data>
+    a                    void:Dataset, dcat:Dataset, schema:Dataset ;
+    schema:dateCreated   "2020-05-30"^^xsd:date ; # The date on which the CreativeWork was created or the item was added to a DataFeed.
+    schema:datePublished "2020-05-30"^^xsd:date ; # Date of first broadcast/publication.
+    schema:dateModified  "2020-05-30"^^xsd:date ; # The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
+
+    schema:workExample   <data/2> ;
+.
+
+<data/2>
+    a          schema:CreativeWork ;
+    schema:url <https://some/url> ;
+.
+
+<https://some/url>
+    a            schema:DefinedTermSet ;
+    rdfs:seeAlso <data> ;
+.

--- a/test/support/dataset_description.ttl
+++ b/test/support/dataset_description.ttl
@@ -1,36 +1,11 @@
 BASE <http://example.org/>
 PREFIX void:   <http://rdfs.org/ns/void#>
 PREFIX dcat:   <http://www.w3.org/ns/dcat#>
-
-PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
-PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
 PREFIX schema: <http://schema.org/>
-PREFIX wd:     <http://www.wikidata.org/entity/>
-PREFIX org:    <https://ld.admin.ch/org/>
-
-
-<>
-    schema:dataset      <data> ;
-    foaf:topic          <data> ;
-    <dateSomethingElse> "2001-05-30"^^xsd:date
-.
 
 <data>
     a                    void:Dataset, dcat:Dataset, schema:Dataset ;
     schema:dateCreated   "2020-05-30"^^xsd:date ; # The date on which the CreativeWork was created or the item was added to a DataFeed.
-    schema:datePublished "2020-05-30"^^xsd:date ; # Date of first broadcast/publication.
     schema:dateModified  "2020-05-30"^^xsd:date ; # The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
-
-    schema:workExample   <data/2> ;
-.
-
-<data/2>
-    a          schema:CreativeWork ;
-    schema:url <https://some/url> ;
-.
-
-<https://some/url>
-    a            schema:DefinedTermSet ;
-    rdfs:seeAlso <data> ;
 .

--- a/test/support/file.unknown.extension
+++ b/test/support/file.unknown.extension
@@ -1,0 +1,1 @@
+Contents


### PR DESCRIPTION
Say you have a dataset_description.ttl file containing:

```turtle
<http://example.org/test> a <http://schema.org/Dataset> .
```

Then a step:

```turtle
<attachMetadata>
    a                  p:Step ;
    rdfs:label         "Attach metadata" ;
    code:implementedBy [ a         code:EcmaScriptModule ;
                         code:link <node:barnard59-rdf/metadata.js#append> ] ;
    code:arguments [
					   code:name "input"; code:value "../some_path/dataset_description.ttl"
				   ],
				   [
					   code:name "dateCreated";
					   code:value  "2020-05-30";
				   ],
				   [
					   code:name "dateModified";
					   code:value  "TIME_NOW";
				   ]

```

will append the contents of dataset_description.ttl to the stream, with new or updated schema.dateModified or schema.dateCreated properties.

```turtle
<http://example.org/test> <http://schema.org/dateModified> "2022-04-13T08:55:21.363Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://example.org/test> <http://schema.org/dateCreated> "2020-05-30"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
```

Current namedDateLiterals: TIME_NOW, TIME_FILE_CREATION, TIME_FILE_MODIFICATION
optional attributes: basepath, graph

Docs: https://github.com/zazuko/barnard59-rdf/pull/18/commits/63df162b2e1f9e5ec25d71dbb5a358486bbaa1e9