### PR TITLE
Added a step to add part-whole relations

### DIFF
--- a/lib/membership.js
+++ b/lib/membership.js
@@ -1,0 +1,86 @@
+import TermSet from '@rdfjs/term-set'
+import rdf from 'rdf-ext'
+import { Transform } from 'readable-stream'
+import * as ns from './namespaces.js'
+
+class AddRelations extends Transform {
+  constructor (context, {
+    createRelation,
+    additionalQuads,
+    classes
+  }) {
+    super({ objectMode: true })
+    this.classes = classes
+    this.createRelation = createRelation
+    this.additionalQuads = additionalQuads
+  }
+
+  _transform (chunk, encoding, callback) {
+    if (chunk.predicate.equals(ns.rdf.type) && this.classes.has(chunk.object)) {
+      const quad = this.createRelation(chunk.subject)
+      this.push(quad)
+    }
+    callback(null, chunk)
+  }
+
+  async _flush (callback) {
+    this.additionalQuads.forEach(quad => this.push(quad))
+    callback()
+  }
+}
+
+const toNamedNode = item => typeof item === 'string' ? rdf.namedNode(item) : item
+
+function toTarget ({
+  targetUri,
+  targetClass,
+  property,
+  classes = []
+} = {}) {
+  if (!targetUri) {
+    throw new Error('Needs targetUri as parameter')
+  }
+  if (!targetClass) {
+    throw new Error('Needs targetClass as parameter')
+  }
+  if (!property) {
+    throw new Error('Needs property as parameter (example http://purl.org/dc/terms/hasPart)')
+  }
+  if (!classes.length) {
+    throw new Error('Needs a list of classes to link')
+  }
+
+  return new AddRelations(this, {
+    createRelation: sourceUri => rdf.quad(sourceUri, property, targetUri),
+    additionalQuads: [rdf.quad(toNamedNode(targetUri), ns.rdf.type, toNamedNode(targetClass))],
+    classes: new TermSet(classes.map(toNamedNode))
+  })
+}
+
+function fromSource ({
+  sourceUri,
+  sourceClass,
+  property,
+  classes = []
+} = {}) {
+  if (!sourceUri) {
+    throw new Error('Needs sourceUri as parameter')
+  }
+  if (!sourceClass) {
+    throw new Error('Needs sourceClass as parameter')
+  }
+  if (!property) {
+    throw new Error('Needs property as parameter (example http://purl.org/dc/terms/isPartOf)')
+  }
+  if (!classes.length) {
+    throw new Error('Needs a list of classes to link')
+  }
+
+  return new AddRelations(this, {
+    createRelation: targetUri => rdf.quad(sourceUri, property, targetUri),
+    additionalQuads: [rdf.quad(toNamedNode(sourceUri), ns.rdf.type, toNamedNode(sourceClass))],
+    classes: new TermSet(classes.map(toNamedNode))
+  })
+}
+
+export { toTarget, fromSource }

--- a/members.js
+++ b/members.js
@@ -1,0 +1,3 @@
+import { toTarget, fromSource } from './lib/membership.js'
+
+export { toTarget, fromSource }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "isstream": "^0.1.2",
     "mocha": "^9.0.1",
     "nock": "^13.2.4",
-    "stricter-standard": "^0.2.0"
+    "stricter-standard": "^0.2.0",
+    "assert": "^2.0.0"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/test/membership.test.js
+++ b/test/membership.test.js
@@ -1,0 +1,140 @@
+import { equal, strictEqual } from 'assert'
+import assert from 'assert/strict'
+import namespace from '@rdfjs/namespace'
+import getStream from 'get-stream'
+import { isDuplex } from 'isstream'
+import { describe, it } from 'mocha'
+import rdf from 'rdf-ext'
+import { Readable } from 'readable-stream'
+import append from '../lib/append.js'
+import { toTarget, fromSource } from '../lib/membership.js'
+import * as ns from '../lib/namespaces.js'
+
+const ex = namespace('http://example.org/')
+
+function toCanonical (quads) {
+  const dataset = rdf.dataset().addAll(quads)
+  return dataset.toCanonical()
+}
+
+describe('membership.toTarget', () => {
+  it('should be a factory', () => {
+    strictEqual(typeof append, 'function')
+  })
+
+  const parameterSet = [
+    { targetUri: undefined, targetClass: ex.targetClass, property: ex.property, classes: [ex.class] },
+    { targetUri: ex.targetUri, targetClass: undefined, property: ex.property, classes: [ex.class] },
+    { targetUri: ex.targetUri, targetClass: ex.targetClass, property: undefined, classes: [ex.class] },
+    { targetUri: ex.targetUri, targetClass: ex.targetClass, property: ex.property, classes: undefined },
+    { targetUri: ex.targetUri, targetClass: ex.targetClass, property: ex.property, classes: [] }
+  ]
+  parameterSet.forEach(params => {
+    it('should throw an error if a mandatory parameter is missing', async () => {
+      assert.throws(() => {
+        toTarget(params)
+      }, Error)
+    })
+  })
+
+  it('should return a duplex stream with valid parameters', () => {
+    const step = toTarget({
+      targetUri: ex.targetUri,
+      targetClass: ex.targetClass,
+      property: ex.property,
+      classes: [ex.class]
+    })
+    strictEqual(isDuplex(step), true)
+  })
+
+  it('should append meta-data to the data', async () => {
+    const data = [
+      rdf.quad(ex.bob, ns.rdf.type, ex.Person),
+      rdf.quad(ex.alice, ns.rdf.type, ex.Person),
+      rdf.quad(ex.fido, ns.rdf.type, ex.Dog),
+      rdf.quad(ex.tom, ns.rdf.type, ex.Cat)
+    ]
+
+    const expectedMetadata = [
+      rdf.quad(ex.bob, ex.in, ex.house),
+      rdf.quad(ex.alice, ex.in, ex.house),
+      rdf.quad(ex.tom, ex.in, ex.house),
+      rdf.quad(ex.house, ns.rdf.type, ex.Container)
+    ]
+
+    const step = toTarget({
+      targetUri: ex.house,
+      targetClass: ex.Container,
+      property: ex.in,
+      classes: [ex.Person, ex.Cat]
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    equal(
+      toCanonical(result),
+      toCanonical([...data, ...expectedMetadata])
+    )
+  })
+})
+
+describe('membership.fromSource', () => {
+  it('should be a factory', () => {
+    strictEqual(typeof append, 'function')
+  })
+
+  const parameterSet = [
+    { sourceUri: undefined, sourceClass: ex.sourceClass, property: ex.property, classes: [ex.class] },
+    { sourceUri: ex.sourceUri, sourceClass: undefined, property: ex.property, classes: [ex.class] },
+    { sourceUri: ex.sourceUri, sourceClass: ex.sourceClass, property: undefined, classes: [ex.class] },
+    { sourceUri: ex.sourceUri, sourceClass: ex.sourceClass, property: ex.property, classes: undefined },
+    { sourceUri: ex.sourceUri, sourceClass: ex.sourceClass, property: ex.property, classes: [] }
+  ]
+  parameterSet.forEach(params => {
+    it('should throw an error if a mandatory parameter is missing', async () => {
+      assert.throws(() => {
+        fromSource(params)
+      }, Error)
+    })
+  })
+
+  it('should return a duplex stream with valid parameters', () => {
+    const step = fromSource({
+      sourceUri: ex.house,
+      sourceClass: ex.Container,
+      property: ex.contains,
+      classes: [ex.Person, ex.Cat]
+    })
+    strictEqual(isDuplex(step), true)
+  })
+
+  it('should append meta-data to the data', async () => {
+    const data = [
+      rdf.quad(ex.bob, ns.rdf.type, ex.Person),
+      rdf.quad(ex.alice, ns.rdf.type, ex.Person),
+      rdf.quad(ex.fido, ns.rdf.type, ex.Dog),
+      rdf.quad(ex.tom, ns.rdf.type, ex.Cat)
+    ]
+
+    const expectedMetadata = [
+      rdf.quad(ex.house, ex.contains, ex.bob),
+      rdf.quad(ex.house, ex.contains, ex.alice),
+      rdf.quad(ex.house, ex.contains, ex.tom),
+      rdf.quad(ex.house, ns.rdf.type, ex.Container)
+    ]
+
+    const step = fromSource({
+      sourceUri: ex.house,
+      sourceClass: ex.Container,
+      property: ex.contains,
+      classes: [ex.Person, ex.Cat]
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    equal(
+      toCanonical(result),
+      toCanonical([...data, ...expectedMetadata])
+    )
+  })
+})


### PR DESCRIPTION
https://github.com/zazuko/issues-private/issues/27#event-5866004620

This is a draft (with probably many naming issues). 

of two operations to add whole-part relations. These are useful to generate a DataCatalog, Partition,  etc

## membership#fromSource

Given the data:

```turtle
<http://example.org/alice> a <http://example.org/Person> .
<http://example.org/bob> a <http://example.org/Person> .
<http://example.org/fido>  a <http://example.org/Dog> .
<http://example.org/tom> a <http://example.org/Cat> .
```
The Operation:

```js
    const operation = fromSource({
      sourceUri: ex.house,
      sourceClass: ex.Container,
      property: ex.contains,
      classes: [ex.Person, ex.Cat]
    })
```

Produces:

```turtle
<http://example.org/house> <http://example.org/contains> <http://example.org/alice> .
<http://example.org/house> <http://example.org/contains> <http://example.org/bob> .
<http://example.org/house> <http://example.org/contains> <http://example.org/tom> .
<http://example.org/house> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Container> .
```

## membership#toTarget

The operation 

```js
  const step = toTarget({
    targetUri: ex.house,
    targetClass: ex.Container,
    property: ex.in,
    classes: [ex.Person, ex.Cat]
  })
```

Produces:
```turtle
<http://example.org/alice> <http://example.org/in> <http://example.org/house> .
<http://example.org/bob> <http://example.org/in> <http://example.org/house> .
<http://example.org/house> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Container> .
<http://example.org/tom> <http://example.org/in> <http://example.org/house> .
```


