### PR TITLE
Void stats

### DIFF
--- a/docs/metadata#append.md
+++ b/docs/metadata#append.md
@@ -1,7 +1,5 @@
 
-# Metadata operation
-
-## Append
+# Metadata Append operation
 
 Say you have a `dataset_description.ttl` file containing:
 
@@ -42,23 +40,23 @@ will append the contents of `dataset_description.ttl` to the stream, with new or
 <http://example.org/test> <http://schema.org/dateCreated> "2020-05-30"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
 ```
 
-### Parameters
+## Parameters
 
-#### input
+### input
 
 The quads to append. Can be a file, a quad stream or an URL pointing to the resource.
 
-### Optional parameters
+## Optional parameters
 
-#### basepath
+### basepath
 
 Sets the base path used to fetch the file.
 
-#### graph
+### graph
 
 The namedgraph used for the incoming metadata quads.
 
-### Dataset Classes
+## Dataset Classes
 
 The operation updates subjects with a type that's a 'well known dataset class', currently:
 
@@ -72,16 +70,16 @@ That will add or modify the `dcterms:created` and `dcterms:modified` properties,
 
 that will add or modify the `schema:dateCreated` and `schema:dateUpdated` properties.
   
-### Named Date Literals
+## Named Date Literals
 
-#### TIME_NOW
+### TIME_NOW
 
 The current time
 
-#### TIME_FILE_CREATION
+### TIME_FILE_CREATION
 
 The file creation time. Applies only to files
 
-#### TIME_FILE_MODIFICATION
+### TIME_FILE_MODIFICATION
 
 The file modification time. Applies only to files

--- a/docs/metadata#voidStats.md
+++ b/docs/metadata#voidStats.md
@@ -1,0 +1,43 @@
+
+# Metadata voidStats operation
+
+Say you have the following stream:
+
+```turtle
+```
+
+Then a step:
+
+```turtle
+
+```
+
+will yield:
+
+```turtle
+
+```
+
+## Parameters
+
+### voidDatasetUri
+
+The URI of the dataset
+
+## Optional parameters
+
+### classPartitions
+
+A list of classes to include in the stats
+
+### propertyPartitions
+
+A list of properties to include in the stats
+
+### includeTotals
+
+Include the total number of entities and triples in the stats. Defaults to false
+
+### graph
+
+The named graph used by the stats

--- a/docs/metadata#voidStats.md
+++ b/docs/metadata#voidStats.md
@@ -4,18 +4,61 @@
 Say you have the following stream:
 
 ```turtle
+@prefix ex: <https://example.org/> .
+
+ex:Alice a ex:Person ;
+    ex:name "Alice" .
+
+ex:Bob a ex:Person ;
+    ex:friendOf ex:Alice ;
+    ex:name "Bob" .
 ```
 
 Then a step:
 
 ```turtle
+@prefix ex: <https://example.org/> .
+@prefix p:    <https://pipeline.described.at/> .
+@prefix code: <https://code.described.at/> .
 
+ex:step a p:Step ;
+        code:implementedBy [
+              a code:EcmaScriptModule ;
+              code:link <node:barnard59-rdf/metadata.js#voidStats>
+          ] ;
+        code:arguments [ code:name "voidDatasetUri"; code:value "https://example.org/dataset" ],
+        [ code:name "classPartitions"; code:value ( "https://example.org/Person" ) ],
+        [ code:name "propertyPartitions"; code:value ( "https://example.org/friendOf" "https://example.org/name" ) ] .
 ```
 
 will yield:
 
 ```turtle
 
+@prefix ex: <https://example.org/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+ex:Alice a ex:Person ;
+         ex:name "Alice" .
+
+ex:Bob a ex:Person ;
+       ex:friendOf ex:Alice ;
+       ex:name "Bob" .
+
+ex:dataset a void:Dataset ;
+           void:triples 5 ;
+          void:entities 2 ;
+          void:classPartition <https://example.org/dataset/classPartition/0> ;
+          void:propertyPartition <https://example.org/dataset/propertyPartition/0>, <https://example.org/dataset/propertyPartition/1> .
+
+<https://example.org/dataset/classPartition/0> void:entities 2 ;
+                                               void:class ex:Person .
+
+<https://example.org/dataset/propertyPartition/0> void:entities 1 ;
+                                                  void:property ex:friendOf .
+
+<https://example.org/dataset/propertyPartition/1> void:entities 2 ;
+                                                  void:property ex:name .
 ```
 
 ## Parameters

--- a/lib/voidStats.js
+++ b/lib/voidStats.js
@@ -1,0 +1,121 @@
+import rdf from 'rdf-ext'
+import { Transform } from 'readable-stream'
+import * as ns from './namespaces.js'
+import { xsd } from './namespaces.js'
+
+class VoidStats extends Transform {
+  constructor (context, {
+    voidDatasetUri,
+    classPartitions,
+    propertyPartitions,
+    includeTotals,
+    graph
+  }) {
+    super({ objectMode: true })
+    this.voidDatasetUri = voidDatasetUri
+    this.includeTotals = includeTotals
+    this.graph = graph
+
+    this.classPartitionsCounts = new Map()
+    classPartitions.forEach(current => {
+      this.classPartitionsCounts.set(current, 0)
+    })
+
+    this.propertyPartitionsCounts = new Map()
+    propertyPartitions.forEach(current => {
+      this.propertyPartitionsCounts.set(current, 0)
+    })
+
+    this.totalTripleCount = 0
+    this.totalEntityCount = 0
+  }
+
+  _transform (chunk, encoding, callback) {
+    this.totalTripleCount++
+
+    if (chunk.predicate.equals(ns.rdf.type)) {
+      this.totalEntityCount++
+      for (const [key, value] of this.classPartitionsCounts) {
+        if (chunk.object.equals(key)) {
+          this.classPartitionsCounts.set(key, value + 1)
+        }
+      }
+    }
+
+    for (const [key, value] of this.propertyPartitionsCounts) {
+      if (chunk.predicate.equals(key)) {
+        this.propertyPartitionsCounts.set(key, value + 1)
+      }
+    }
+
+    callback(null, chunk)
+  }
+
+  async _flush (callback) {
+    try {
+      const datasetUri = toNamedNode(this.voidDatasetUri)
+      const datasetGraph = this.graph ? toNamedNode(this.graph) : undefined
+
+      this.push(rdf.quad(datasetUri, ns.rdf.type, ns._void.Dataset, datasetGraph))
+      if (this.includeTotals) {
+        this.push(rdf.quad(datasetUri, ns._void.triples, rdf.literal(this.totalTripleCount, xsd.integer), datasetGraph))
+        this.push(rdf.quad(datasetUri, ns._void.entities, rdf.literal(this.totalEntityCount, xsd.integer), datasetGraph))
+      }
+
+      if (this.classPartitionsCounts.size) {
+        let i = 0
+        for (const [currentClass, count] of this.classPartitionsCounts) {
+          const classPartitionUri = rdf.blankNode(`b_class_partition_${i}`)
+          this.push(rdf.quad(datasetUri, ns._void.classPartition, classPartitionUri, datasetGraph))
+          this.push(rdf.quad(classPartitionUri, ns._void.class, currentClass, datasetGraph))
+          this.push(rdf.quad(classPartitionUri, ns._void.entities, rdf.literal(count, xsd.integer), datasetGraph))
+          i += 1
+        }
+      }
+
+      if (this.propertyPartitionsCounts.size) {
+        let i = 0
+        for (const [currentProperty, count] of this.propertyPartitionsCounts) {
+          const propertyPartitionUri = rdf.blankNode(`b_property_partition_${i}`)
+          this.push(rdf.quad(datasetUri, ns._void.propertyPartition, propertyPartitionUri, datasetGraph))
+          this.push(rdf.quad(propertyPartitionUri, ns._void.property, currentProperty, datasetGraph))
+          this.push(rdf.quad(propertyPartitionUri, ns._void.entities, rdf.literal(count, xsd.integer), datasetGraph))
+          i += 1
+        }
+      }
+    } catch (err) {
+      this.destroy(err)
+    } finally {
+      callback()
+    }
+  }
+}
+
+function toNamedNode (item) {
+  if (item === undefined) {
+    return undefined
+  }
+  return typeof item === 'string' ? rdf.namedNode(item) : item
+}
+
+function graphStats ({
+  voidDatasetUri = undefined,
+  classPartitions = [],
+  propertyPartitions = [],
+  includeTotals = true,
+  graph = undefined
+} = {}) {
+  if (!voidDatasetUri) {
+    throw new Error('Needs voidDatasetUri as parameter')
+  }
+
+  return new VoidStats(this, {
+    voidDatasetUri: toNamedNode(voidDatasetUri),
+    classPartitions: classPartitions.map(toNamedNode),
+    propertyPartitions: propertyPartitions.map(toNamedNode),
+    includeTotals,
+    graph: toNamedNode(graph)
+  })
+}
+
+export default graphStats

--- a/manifest.ttl
+++ b/manifest.ttl
@@ -37,3 +37,10 @@
   code:implementedBy [ a code:EcmaScript;
                        code:link <node:barnard59-rdf/metadata.js#append>
   ].
+
+<metadata.js#voidStats> a p:Operation, p:WritableObjectMode, p:ReadableObjectMode;
+ rdfs:label "Void statistics";
+ rdfs:comment "Appends void statistics, such as counts for entities and properties";
+ code:implementedBy [ a code:EcmaScript;
+                      code:link <node:barnard59-rdf/metadata.js#voidStats>
+                    ].

--- a/metadata.js
+++ b/metadata.js
@@ -1,3 +1,4 @@
 import append from './lib/append.js'
+import voidStats from './lib/voidStats.js'
 
-export { append }
+export { append, voidStats }

--- a/test/voidStats.test.js
+++ b/test/voidStats.test.js
@@ -1,4 +1,4 @@
-import { strictEqual } from 'assert'
+import { equal, strictEqual } from 'assert'
 import namespace from '@rdfjs/namespace'
 import assertThrows from 'assert-throws-async'
 import getStream from 'get-stream'
@@ -18,13 +18,13 @@ describe('metadata.voidStats', () => {
     strictEqual(typeof voidStats, 'function')
   })
 
-  it('should throw an error if no argument is given', async () => {
+  it('throws an error if no argument is given', async () => {
     await assertThrows(async () => {
       await voidStats()
     }, Error, /Needs voidDatasetUri as parameter/)
   })
 
-  it('should return a duplex stream with default values for voidDatasetUri', async () => {
+  it('return a duplex stream with default values for voidDatasetUri', async () => {
     const step = await voidStats(
       {
         voidDatasetUri: ex.dataset
@@ -32,12 +32,12 @@ describe('metadata.voidStats', () => {
     strictEqual(isDuplex(step), true)
   })
 
-  function toN3 (quads) {
+  function toCanonical (quads) {
     const dataset = rdf.dataset().addAll(quads)
-    return dataset.toString()
+    return dataset.toCanonical()
   }
 
-  it('should include counts at the end of the stream', async () => {
+  it('includes counts at the end of the stream', async () => {
     const data = [
       rdf.quad(ex.bob, ns.rdf.type, ex.Person),
       rdf.quad(ex.alice, ns.rdf.type, ex.Person),
@@ -46,8 +46,8 @@ describe('metadata.voidStats', () => {
     ]
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
-      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(4, ns.xsd.integer)),
-      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(2, ns.xsd.integer))
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal('4', ns.xsd.integer)),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal('2', ns.xsd.integer))
     ]
     const inputStream = Readable.from(data)
 
@@ -57,16 +57,18 @@ describe('metadata.voidStats', () => {
 
     const result = await getStream.array(inputStream.pipe(sut))
 
-    strictEqual(result.length, 7)
-    strictEqual(toN3(result.slice(4)), toN3(expectedMetadata), true)
+    equal(
+      toCanonical(result.slice(4)),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('should return zero counts for no data', async () => {
+  it('returns zero counts for no data', async () => {
     const data = []
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
-      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(0, ns.xsd.integer)),
-      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(0, ns.xsd.integer))
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal('0', ns.xsd.integer)),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal('0', ns.xsd.integer))
     ]
     const inputStream = Readable.from(data)
 
@@ -76,18 +78,21 @@ describe('metadata.voidStats', () => {
 
     const result = await getStream.array(inputStream.pipe(sut))
 
-    strictEqual(toN3(result), toN3(expectedMetadata), true)
+    equal(
+      toCanonical(result),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('No classes result in entity count 0', async () => {
+  it('returns zero counts for 0 classes', async () => {
     const data = [
       rdf.quad(ex.bob, ex.knows, ex.alice),
       rdf.quad(ex.alice, ex.name, rdf.literal('Alice'))
     ]
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
-      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(2, ns.xsd.integer)),
-      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(0, ns.xsd.integer))
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal('2', ns.xsd.integer)),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal('0', ns.xsd.integer))
     ]
     const inputStream = Readable.from(data)
 
@@ -97,16 +102,18 @@ describe('metadata.voidStats', () => {
 
     const result = await getStream.array(inputStream.pipe(sut))
 
-    strictEqual(result.length, 5)
-    strictEqual(toN3(result.slice(2)), toN3(expectedMetadata), true)
+    equal(
+      toCanonical(result.slice(2)),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('metadata use the graph defined as parameter', async () => {
+  it('uses the named-graph given as parameter', async () => {
     const data = []
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset, ex.metadata),
-      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(0, ns.xsd.integer), ex.metadata),
-      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(0, ns.xsd.integer), ex.metadata)
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal('0', ns.xsd.integer), ex.metadata),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal('0', ns.xsd.integer), ex.metadata)
     ]
     const inputStream = Readable.from(data)
 
@@ -116,10 +123,14 @@ describe('metadata.voidStats', () => {
     })
 
     const result = await getStream.array(inputStream.pipe(sut))
-    strictEqual(toN3(result), toN3(expectedMetadata), true)
+
+    equal(
+      toCanonical(result),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('should not include total counts with includeTotals: false', async () => {
+  it('does not include total counts with includeTotals: false', async () => {
     const data = [
       rdf.quad(ex.bob, ex.knows, ex.alice),
       rdf.quad(ex.alice, ex.name, rdf.literal('Alice'))
@@ -136,25 +147,29 @@ describe('metadata.voidStats', () => {
 
     const result = await getStream.array(inputStream.pipe(sut))
 
-    strictEqual(result.length, 3)
-    strictEqual(toN3(result.slice(2)), toN3(expectedMetadata), true)
+    equal(
+      toCanonical(result.slice(2)),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('should describe counts for class partitions', async () => {
+  it('describes counts for class partitions', async () => {
     const data = [
       rdf.quad(ex.a_1, ns.rdf.type, ex.A),
       rdf.quad(ex.a_2, ns.rdf.type, ex.A),
       rdf.quad(ex.b_1, ns.rdf.type, ex.B),
       rdf.quad(ex.c_1, ns.rdf.type, ex.C)
     ]
+    const partition1 = rdf.namedNode('http://example.org/dataset/classPartition/0')
+    const partition2 = rdf.namedNode('http://example.org/dataset/classPartition/1')
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
-      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_0')),
-      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_1')),
-      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.class, ex.A),
-      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.entities, rdf.literal(2, ns.xsd.integer)),
-      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.class, ex.C),
-      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.entities, rdf.literal(1, ns.xsd.integer))
+      rdf.quad(ex.dataset, ns._void.classPartition, partition1),
+      rdf.quad(ex.dataset, ns._void.classPartition, partition2),
+      rdf.quad(partition1, ns._void.class, ex.A),
+      rdf.quad(partition1, ns._void.entities, rdf.literal('2', ns.xsd.integer)),
+      rdf.quad(partition2, ns._void.class, ex.C),
+      rdf.quad(partition2, ns._void.entities, rdf.literal('1', ns.xsd.integer))
     ]
     const inputStream = Readable.from(data)
 
@@ -163,21 +178,27 @@ describe('metadata.voidStats', () => {
       classPartitions: [ex.A, ex.C],
       includeTotals: false
     })
+
     const result = await getStream.array(inputStream.pipe(sut))
-    strictEqual(result.length, 11)
-    strictEqual(toN3(result.slice(4)), toN3(expectedMetadata), true)
+
+    equal(
+      toCanonical(result.slice(4)),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('should describe counts for class partitions with no matches', async () => {
+  it('describe counts for class partitions with no matches', async () => {
     const data = []
+    const partition1 = rdf.namedNode('http://example.org/dataset/classPartition/0')
+    const partition2 = rdf.namedNode('http://example.org/dataset/classPartition/1')
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
-      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_0')),
-      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_1')),
-      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.class, ex.A),
-      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.entities, rdf.literal(0, ns.xsd.integer)),
-      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.class, ex.C),
-      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.entities, rdf.literal(0, ns.xsd.integer))
+      rdf.quad(ex.dataset, ns._void.classPartition, partition1),
+      rdf.quad(ex.dataset, ns._void.classPartition, partition2),
+      rdf.quad(partition1, ns._void.class, ex.A),
+      rdf.quad(partition1, ns._void.entities, rdf.literal('0', ns.xsd.integer)),
+      rdf.quad(partition2, ns._void.class, ex.C),
+      rdf.quad(partition2, ns._void.entities, rdf.literal('0', ns.xsd.integer))
     ]
     const inputStream = Readable.from(data)
 
@@ -186,26 +207,32 @@ describe('metadata.voidStats', () => {
       classPartitions: [ex.A, ex.C],
       includeTotals: false
     })
+
     const result = await getStream.array(inputStream.pipe(sut))
-    strictEqual(result.length, 7)
-    strictEqual(toN3(result), toN3(expectedMetadata), true)
+
+    equal(
+      toCanonical(result),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('should describe counts for property partitions', async () => {
+  it('describe counts for property partitions', async () => {
     const data = [
       rdf.quad(ex.a, ex.p_1, ex.b),
       rdf.quad(ex.a, ex.p_1, ex.b),
       rdf.quad(ex.a, ex.p_2, ex.b),
       rdf.quad(ex.a, ex.p_3, ex.b)
     ]
+    const partition1 = rdf.namedNode('http://example.org/dataset/propertyPartition/0')
+    const partition2 = rdf.namedNode('http://example.org/dataset/propertyPartition/1')
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
-      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_0')),
-      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_1')),
-      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.property, ex.p_1),
-      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.entities, rdf.literal(2, ns.xsd.integer)),
-      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.property, ex.p_3),
-      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.entities, rdf.literal(1, ns.xsd.integer))
+      rdf.quad(ex.dataset, ns._void.propertyPartition, partition1),
+      rdf.quad(ex.dataset, ns._void.propertyPartition, partition2),
+      rdf.quad(partition1, ns._void.property, ex.p_1),
+      rdf.quad(partition1, ns._void.entities, rdf.literal('2', ns.xsd.integer)),
+      rdf.quad(partition2, ns._void.property, ex.p_3),
+      rdf.quad(partition2, ns._void.entities, rdf.literal('1', ns.xsd.integer))
     ]
     const inputStream = Readable.from(data)
 
@@ -214,21 +241,27 @@ describe('metadata.voidStats', () => {
       propertyPartitions: [ex.p_1, ex.p_3],
       includeTotals: false
     })
+
     const result = await getStream.array(inputStream.pipe(sut))
-    strictEqual(result.length, 11)
-    strictEqual(toN3(result.slice(4)), toN3(expectedMetadata), true)
+
+    equal(
+      toCanonical(result.slice(4)),
+      toCanonical(expectedMetadata)
+    )
   })
 
-  it('should describe counts for property partitions with no matches', async () => {
+  it('describe counts for property partitions with no matches', async () => {
     const data = []
+    const partition1 = rdf.namedNode('http://example.org/dataset/propertyPartition/0')
+    const partition2 = rdf.namedNode('http://example.org/dataset/propertyPartition/1')
     const expectedMetadata = [
       rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
-      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_0')),
-      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_1')),
-      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.property, ex.p_1),
-      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.entities, rdf.literal(0, ns.xsd.integer)),
-      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.property, ex.p_3),
-      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.entities, rdf.literal(0, ns.xsd.integer))
+      rdf.quad(ex.dataset, ns._void.propertyPartition, partition1),
+      rdf.quad(ex.dataset, ns._void.propertyPartition, partition2),
+      rdf.quad(partition1, ns._void.property, ex.p_1),
+      rdf.quad(partition1, ns._void.entities, rdf.literal('0', ns.xsd.integer)),
+      rdf.quad(partition2, ns._void.property, ex.p_3),
+      rdf.quad(partition2, ns._void.entities, rdf.literal('0', ns.xsd.integer))
     ]
     const inputStream = Readable.from(data)
 
@@ -237,9 +270,13 @@ describe('metadata.voidStats', () => {
       includeTotals: false,
       propertyPartitions: [ex.p_1, ex.p_3]
     })
+
     const result = await getStream.array(inputStream.pipe(sut))
-    strictEqual(result.length, 7)
-    strictEqual(toN3(result), toN3(expectedMetadata), true)
+
+    equal(
+      toCanonical(result),
+      toCanonical(expectedMetadata)
+    )
   })
 
   it('accepts string parameters', async () => {
@@ -261,7 +298,9 @@ describe('metadata.voidStats', () => {
       graph: ex.graph.value,
       includeTotals: true
     })
+
     const result = await getStream.array(inputStream.pipe(sut))
+
     strictEqual(result.length, 17)
 
     for (const quad of result.slice(8)) {

--- a/test/voidStats.test.js
+++ b/test/voidStats.test.js
@@ -1,0 +1,271 @@
+import { strictEqual } from 'assert'
+import namespace from '@rdfjs/namespace'
+import assertThrows from 'assert-throws-async'
+import getStream from 'get-stream'
+import { isDuplex } from 'isstream'
+import { describe, it } from 'mocha'
+import rdf from 'rdf-ext'
+import { Readable } from 'readable-stream'
+import * as ns from '../lib/namespaces.js'
+import voidStats from '../lib/voidStats.js'
+
+const ex = namespace('http://example.org/')
+/**
+ * https://www.w3.org/TR/void/#statistics
+ */
+describe('metadata.voidStats', () => {
+  it('should be a factory', () => {
+    strictEqual(typeof voidStats, 'function')
+  })
+
+  it('should throw an error if no argument is given', async () => {
+    await assertThrows(async () => {
+      await voidStats()
+    }, Error, /Needs voidDatasetUri as parameter/)
+  })
+
+  it('should return a duplex stream with default values for voidDatasetUri', async () => {
+    const step = await voidStats(
+      {
+        voidDatasetUri: ex.dataset
+      })
+    strictEqual(isDuplex(step), true)
+  })
+
+  function toN3 (quads) {
+    const dataset = rdf.dataset().addAll(quads)
+    return dataset.toString()
+  }
+
+  it('should include counts at the end of the stream', async () => {
+    const data = [
+      rdf.quad(ex.bob, ns.rdf.type, ex.Person),
+      rdf.quad(ex.alice, ns.rdf.type, ex.Person),
+      rdf.quad(ex.bob, ex.knows, ex.alice),
+      rdf.quad(ex.alice, ex.name, rdf.literal('Alice'))
+    ]
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(4, ns.xsd.integer)),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(2, ns.xsd.integer))
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset
+    })
+
+    const result = await getStream.array(inputStream.pipe(sut))
+
+    strictEqual(result.length, 7)
+    strictEqual(toN3(result.slice(4)), toN3(expectedMetadata), true)
+  })
+
+  it('should return zero counts for no data', async () => {
+    const data = []
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(0, ns.xsd.integer)),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(0, ns.xsd.integer))
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset
+    })
+
+    const result = await getStream.array(inputStream.pipe(sut))
+
+    strictEqual(toN3(result), toN3(expectedMetadata), true)
+  })
+
+  it('No classes result in entity count 0', async () => {
+    const data = [
+      rdf.quad(ex.bob, ex.knows, ex.alice),
+      rdf.quad(ex.alice, ex.name, rdf.literal('Alice'))
+    ]
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(2, ns.xsd.integer)),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(0, ns.xsd.integer))
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset
+    })
+
+    const result = await getStream.array(inputStream.pipe(sut))
+
+    strictEqual(result.length, 5)
+    strictEqual(toN3(result.slice(2)), toN3(expectedMetadata), true)
+  })
+
+  it('metadata use the graph defined as parameter', async () => {
+    const data = []
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset, ex.metadata),
+      rdf.quad(ex.dataset, ns._void.triples, rdf.literal(0, ns.xsd.integer), ex.metadata),
+      rdf.quad(ex.dataset, ns._void.entities, rdf.literal(0, ns.xsd.integer), ex.metadata)
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset,
+      graph: ex.metadata
+    })
+
+    const result = await getStream.array(inputStream.pipe(sut))
+    strictEqual(toN3(result), toN3(expectedMetadata), true)
+  })
+
+  it('should not include total counts with includeTotals: false', async () => {
+    const data = [
+      rdf.quad(ex.bob, ex.knows, ex.alice),
+      rdf.quad(ex.alice, ex.name, rdf.literal('Alice'))
+    ]
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset)
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset,
+      includeTotals: false
+    })
+
+    const result = await getStream.array(inputStream.pipe(sut))
+
+    strictEqual(result.length, 3)
+    strictEqual(toN3(result.slice(2)), toN3(expectedMetadata), true)
+  })
+
+  it('should describe counts for class partitions', async () => {
+    const data = [
+      rdf.quad(ex.a_1, ns.rdf.type, ex.A),
+      rdf.quad(ex.a_2, ns.rdf.type, ex.A),
+      rdf.quad(ex.b_1, ns.rdf.type, ex.B),
+      rdf.quad(ex.c_1, ns.rdf.type, ex.C)
+    ]
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
+      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_0')),
+      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_1')),
+      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.class, ex.A),
+      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.entities, rdf.literal(2, ns.xsd.integer)),
+      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.class, ex.C),
+      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.entities, rdf.literal(1, ns.xsd.integer))
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset,
+      classPartitions: [ex.A, ex.C],
+      includeTotals: false
+    })
+    const result = await getStream.array(inputStream.pipe(sut))
+    strictEqual(result.length, 11)
+    strictEqual(toN3(result.slice(4)), toN3(expectedMetadata), true)
+  })
+
+  it('should describe counts for class partitions with no matches', async () => {
+    const data = []
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
+      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_0')),
+      rdf.quad(ex.dataset, ns._void.classPartition, rdf.blankNode('b_class_partition_1')),
+      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.class, ex.A),
+      rdf.quad(rdf.blankNode('b_class_partition_0'), ns._void.entities, rdf.literal(0, ns.xsd.integer)),
+      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.class, ex.C),
+      rdf.quad(rdf.blankNode('b_class_partition_1'), ns._void.entities, rdf.literal(0, ns.xsd.integer))
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset,
+      classPartitions: [ex.A, ex.C],
+      includeTotals: false
+    })
+    const result = await getStream.array(inputStream.pipe(sut))
+    strictEqual(result.length, 7)
+    strictEqual(toN3(result), toN3(expectedMetadata), true)
+  })
+
+  it('should describe counts for property partitions', async () => {
+    const data = [
+      rdf.quad(ex.a, ex.p_1, ex.b),
+      rdf.quad(ex.a, ex.p_1, ex.b),
+      rdf.quad(ex.a, ex.p_2, ex.b),
+      rdf.quad(ex.a, ex.p_3, ex.b)
+    ]
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
+      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_0')),
+      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_1')),
+      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.property, ex.p_1),
+      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.entities, rdf.literal(2, ns.xsd.integer)),
+      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.property, ex.p_3),
+      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.entities, rdf.literal(1, ns.xsd.integer))
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset,
+      propertyPartitions: [ex.p_1, ex.p_3],
+      includeTotals: false
+    })
+    const result = await getStream.array(inputStream.pipe(sut))
+    strictEqual(result.length, 11)
+    strictEqual(toN3(result.slice(4)), toN3(expectedMetadata), true)
+  })
+
+  it('should describe counts for property partitions with no matches', async () => {
+    const data = []
+    const expectedMetadata = [
+      rdf.quad(ex.dataset, ns.rdf.type, ns._void.Dataset),
+      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_0')),
+      rdf.quad(ex.dataset, ns._void.propertyPartition, rdf.blankNode('b_property_partition_1')),
+      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.property, ex.p_1),
+      rdf.quad(rdf.blankNode('b_property_partition_0'), ns._void.entities, rdf.literal(0, ns.xsd.integer)),
+      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.property, ex.p_3),
+      rdf.quad(rdf.blankNode('b_property_partition_1'), ns._void.entities, rdf.literal(0, ns.xsd.integer))
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset,
+      includeTotals: false,
+      propertyPartitions: [ex.p_1, ex.p_3]
+    })
+    const result = await getStream.array(inputStream.pipe(sut))
+    strictEqual(result.length, 7)
+    strictEqual(toN3(result), toN3(expectedMetadata), true)
+  })
+
+  it('accepts string parameters', async () => {
+    const data = [
+      rdf.quad(ex.a_1, ns.rdf.type, ex.A),
+      rdf.quad(ex.a_2, ns.rdf.type, ex.A),
+      rdf.quad(ex.b_1, ns.rdf.type, ex.B),
+      rdf.quad(ex.c_1, ns.rdf.type, ex.C),
+      rdf.quad(ex.a, ex.p_1, ex.b),
+      rdf.quad(ex.a, ex.p_1, ex.b),
+      rdf.quad(ex.a, ex.p_2, ex.b),
+      rdf.quad(ex.a, ex.p_3, ex.b)
+    ]
+    const inputStream = Readable.from(data)
+
+    const sut = voidStats({
+      voidDatasetUri: ex.dataset.value,
+      propertyPartitions: [ex.p_1.value, ex.p_3.value],
+      graph: ex.graph.value,
+      includeTotals: true
+    })
+    const result = await getStream.array(inputStream.pipe(sut))
+    strictEqual(result.length, 17)
+
+    for (const quad of result.slice(8)) {
+      strictEqual(quad.graph.equals(ex.graph), true)
+    }
+  })
+})


### PR DESCRIPTION

This is the second version of stats, specific for Void.

From:
https://github.com/zazuko/barnard59-rdf/blob/void-stats/docs/metadata%23voidStats.md

# Metadata voidStats operation

Say you have the following stream:

```turtle
@prefix ex: <https://example.org/> .

ex:Alice a ex:Person ;
    ex:name "Alice" .

ex:Bob a ex:Person ;
    ex:friendOf ex:Alice ;
    ex:name "Bob" .
```

Then a step:

```turtle
@prefix ex: <https://example.org/> .
@prefix p:    <https://pipeline.described.at/> .
@prefix code: <https://code.described.at/> .

ex:step a p:Step ;
        code:implementedBy [
              a code:EcmaScriptModule ;
              code:link <node:barnard59-rdf/metadata.js#voidStats>
          ] ;
        code:arguments [ code:name "voidDatasetUri"; code:value "https://example.org/dataset" ],
        [ code:name "classPartitions"; code:value ( "https://example.org/Person" ) ],
        [ code:name "propertyPartitions"; code:value ( "https://example.org/friendOf" "https://example.org/name" ) ] .
```

will yield:

```turtle

@prefix ex: <https://example.org/> .
@prefix void: <http://rdfs.org/ns/void#> .

ex:Alice a ex:Person ;
         ex:name "Alice" .

ex:Bob a ex:Person ;
       ex:friendOf ex:Alice ;
       ex:name "Bob" .

ex:dataset a void:Dataset ;
           void:triples 5 ;
          void:entities 2 ;
          void:classPartition <https://example.org/dataset/classPartition/0> ;
          void:propertyPartition <https://example.org/dataset/propertyPartition/0>, <https://example.org/dataset/propertyPartition/1> .

<https://example.org/dataset/classPartition/0> void:entities 2 ;
                                               void:class ex:Person .

<https://example.org/dataset/propertyPartition/0> void:entities 1 ;
                                                  void:property ex:friendOf .

<https://example.org/dataset/propertyPartition/1> void:entities 2 ;
                                                  void:property ex:name .
```

## Parameters

### voidDatasetUri

The URI of the dataset

## Optional parameters

### classPartitions

A list of classes to include in the stats

### propertyPartitions

A list of properties to include in the stats

### includeTotals

Include the total number of entities and triples in the stats. Defaults to false

### graph

The named graph used by the stats
