### PR TITLE
Fix: generate incorrect data-types if parameters are given as string.

### DIFF
--- a/lib/membership.js
+++ b/lib/membership.js
@@ -51,7 +51,7 @@ function toTarget ({
   }
 
   return new AddRelations(this, {
-    createRelation: sourceUri => rdf.quad(sourceUri, property, targetUri),
+    createRelation: sourceUri => rdf.quad(toNamedNode(sourceUri), toNamedNode(property), toNamedNode(targetUri)),
     additionalQuads: [rdf.quad(toNamedNode(targetUri), ns.rdf.type, toNamedNode(targetClass))],
     classes: new TermSet(classes.map(toNamedNode))
   })
@@ -77,7 +77,7 @@ function fromSource ({
   }
 
   return new AddRelations(this, {
-    createRelation: targetUri => rdf.quad(sourceUri, property, targetUri),
+    createRelation: targetUri => rdf.quad(toNamedNode(sourceUri), toNamedNode(property), toNamedNode(targetUri)),
     additionalQuads: [rdf.quad(toNamedNode(sourceUri), ns.rdf.type, toNamedNode(sourceClass))],
     classes: new TermSet(classes.map(toNamedNode))
   })

--- a/test/membership.test.js
+++ b/test/membership.test.js
@@ -75,6 +75,36 @@ describe('membership.toTarget', () => {
       toCanonical([...data, ...expectedMetadata])
     )
   })
+
+  it('should append meta-data to the data with string parameters', async () => {
+    const data = [
+      rdf.quad(ex.bob, ns.rdf.type, ex.Person),
+      rdf.quad(ex.alice, ns.rdf.type, ex.Person),
+      rdf.quad(ex.fido, ns.rdf.type, ex.Dog),
+      rdf.quad(ex.tom, ns.rdf.type, ex.Cat)
+    ]
+
+    const expectedMetadata = [
+      rdf.quad(ex.bob, ex.in, ex.house),
+      rdf.quad(ex.alice, ex.in, ex.house),
+      rdf.quad(ex.tom, ex.in, ex.house),
+      rdf.quad(ex.house, ns.rdf.type, ex.Container)
+    ]
+
+    const step = toTarget({
+      targetUri: ex.house.value,
+      targetClass: ex.Container.value,
+      property: ex.in.value,
+      classes: [ex.Person.value, ex.Cat.value]
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    equal(
+      toCanonical(result),
+      toCanonical([...data, ...expectedMetadata])
+    )
+  })
 })
 
 describe('membership.fromSource', () => {
@@ -136,4 +166,35 @@ describe('membership.fromSource', () => {
       toCanonical([...data, ...expectedMetadata])
     )
   })
+
+  it('should append meta-data to the data with string parameters', async () => {
+    const data = [
+      rdf.quad(ex.bob, ns.rdf.type, ex.Person),
+      rdf.quad(ex.alice, ns.rdf.type, ex.Person),
+      rdf.quad(ex.fido, ns.rdf.type, ex.Dog),
+      rdf.quad(ex.tom, ns.rdf.type, ex.Cat)
+    ]
+
+    const expectedMetadata = [
+      rdf.quad(ex.house, ex.contains, ex.bob),
+      rdf.quad(ex.house, ex.contains, ex.alice),
+      rdf.quad(ex.house, ex.contains, ex.tom),
+      rdf.quad(ex.house, ns.rdf.type, ex.Container)
+    ]
+
+    const step = fromSource({
+      sourceUri: ex.house.value,
+      sourceClass: ex.Container.value,
+      property: ex.contains.value,
+      classes: [ex.Person.value, ex.Cat.value]
+    })
+
+    const result = await getStream.array(Readable.from(data).pipe(step))
+
+    equal(
+      toCanonical(result),
+      toCanonical([...data, ...expectedMetadata])
+    )
+  })
+
 })


### PR DESCRIPTION
This fixes the generation of incorrect data-types if parameters are given as strings.
